### PR TITLE
Performance, UI consistency, and rendering improvements

### DIFF
--- a/aplogin.js
+++ b/aplogin.js
@@ -8,7 +8,7 @@ function getUrlParameter(name) {
 };
 
 const CHANGELOG_STORAGE_KEY = "jigsawChangelogVersionSeen";
-const CHANGELOG_VERSION = "0.10.0";
+const CHANGELOG_VERSION = "0.10.1";
 
 function showChangelogModal() {
     const overlay = document.getElementById("changelogModal");

--- a/clientandpreview.js
+++ b/clientandpreview.js
@@ -215,6 +215,7 @@ function setMinSizeToContent(draggable, options = {}) {
     if (!draggable) return;
     const enforceHeight = options.enforceHeight !== false;
     const enforceWidth = options.enforceWidth !== false;
+    const setExplicitHeight = options.setExplicitHeight === true;
     requestAnimationFrame(() => {
         const panel = draggable.querySelector('.view-controls-window-panel, .cosmetic-window-panel, .media-window-panel');
         const resizer = draggable.querySelector('.resizer.corner');
@@ -222,7 +223,11 @@ function setMinSizeToContent(draggable, options = {}) {
         const panelW = panel ? panel.scrollWidth : 0;
         const resizerH = resizer ? resizer.offsetHeight : 0;
         if (enforceHeight) {
-            draggable.style.minHeight = Math.ceil(panelH + resizerH) + 'px';
+            const heightPx = Math.ceil(panelH + resizerH) + 'px';
+            draggable.style.minHeight = heightPx;
+            if (setExplicitHeight) {
+                draggable.style.height = heightPx;
+            }
         }
         if (enforceWidth) {
             // Add a small buffer for borders/scrollbars so controls don't clip.
@@ -256,7 +261,7 @@ function restoreDiv6() {
     if (!draggable6) return;
     draggable6.style.display = (draggable6.style.display === 'none') ? 'block' : 'none';
     if (draggable6.style.display === 'block' || draggable6.style.display === '') {
-        setMinSizeToContent(draggable6, { enforceHeight: true, enforceWidth: false });
+        setMinSizeToContent(draggable6, { enforceHeight: true, enforceWidth: false, setExplicitHeight: true });
     }
 }
 

--- a/index.html
+++ b/index.html
@@ -332,6 +332,10 @@
         <label for="showGrayscaleReference" class="display-options-label-inline">Grayscale reference behind pieces</label>
         <input type="checkbox" id="showGrayscaleReference" class="display-options-checkbox" aria-label="Show grayscale reference image behind pieces">
       </div>
+      <div class="display-options-row display-options-row--label-wide" title="Show an outline around the puzzle preview area (size only, no image). Useful when you want to see the puzzle bounds without the grayscale reference.">
+        <label for="showPreviewOutline" class="display-options-label-inline">Preview outline only</label>
+        <input type="checkbox" id="showPreviewOutline" class="display-options-checkbox" aria-label="Show outline around preview area">
+      </div>
       <div class="display-options-row display-options-row--label-wide" title="Show a draggable handle for where new pieces will appear; drag to move it. The drop location is reset when you start a new puzzle.">
         <label for="useCustomDropLocation" class="display-options-label-inline">Show drop location handle</label>
         <input type="checkbox" id="useCustomDropLocation" class="display-options-checkbox" aria-label="Show drop location handle">

--- a/index.html
+++ b/index.html
@@ -140,12 +140,13 @@
         <div class="changelog-entry-title">Version 0.10.1</div>
         <div class="changelog-entry-body">
           <ul>
-            <li><strong>Resolution &amp; display:</strong> Puzzle resolution now supports 1440p, 4K, 8K, and 16K (default stays 1080p). Higher resolutions can affect performance—a tooltip on the dropdown reminds you. The puzzle image uses more of the play area (90% instead of 85%) so pieces look a bit sharper. In Canvas2D, scaling looks better when resolution is capped; in WebGL, piece edges are crisper.</li>
+            <li><strong>Resolution & display:</strong> Puzzle resolution now supports 1440p, 4K, 8K, and 16K (default stays 1080p). Higher resolutions can affect performance—a tooltip on the dropdown reminds you. The puzzle image uses more of the play area (90% instead of 85%) so pieces look a bit sharper. Scaling looks better when resolution is capped, and piece edges are crisper.</li>
             <li><strong>Cleaner, consistent windows:</strong> Chat/Log, View controls, Cosmetic options, Piece drawer, and Load custom media all use the same compact header and layout. Less padding, smaller titles, and the same look everywhere. Chat can be resized shorter; only the content area scrolls. Load custom media opens in the right place and stays on top of other UI.</li>
             <li><strong>Legacy mode for slower devices:</strong> A new “Legacy mode (low‑performance devices)” option in display settings uses a lighter rendering path (Canvas2D only, lower frame rate, no held‑piece shadow) so the game runs better on older tablets and slower PCs. When Legacy mode is on, WebGL is disabled until you turn it off; a short message explains this.</li>
             <li><strong>Performance:</strong> Piece movement is smoother, piece picking is faster, and the piece you’re holding stays on top. Dropping a piece checks only nearby pieces for merges, so drops feel snappier. Resizing the window spreads redraws over several frames so the game stays responsive. The preview/sync window only redraws when it’s open. One animation loop instead of two and fewer things drawn each frame help on slower devices. Several console logs that could slow things down were removed.</li>
             <li><strong>Video and animation:</strong> A new “Video / animation framerate” option (Cosmetics) lets you cap video/GIF updates at 60, 30, 24, 20, or 15 fps (default 30). Lower values reduce load on weaker devices. Video and GIF no longer push at full decode rate, so the game stays responsive. The grayscale reference behind pieces updates less often with video/GIF (about 8 times per second) to save work. Video and GIF now work correctly and more efficiently with both Canvas2D and WebGL.</li>
             <li><strong>Cosmetic options:</strong> “Preview outline only” draws an outline around the puzzle preview so you can see the puzzle size without showing the full grayscale image. The outline follows the actual image area (including square pieces and other layouts).</li>
+            <li><strong>View controls:</strong> The default pan button is now right mouse instead of left, so left-click drag is reserved for selecting pieces. You can still cycle the pan button (Left / Middle / Right) from the View Controls window.</li>
           </ul>
         </div>
       </article>
@@ -252,7 +253,7 @@
         <button id="viewResetButton" class="view-toggle-btn" type="button" title="Reset zoom and pan to the default view (puzzle centered and fitted).">Reset View</button>
       </div>
       <div class="view-controls-row view-controls-row--full">
-        <button id="viewPanButtonToggle" class="view-toggle-btn view-pan-with-btn" type="button" title="Choose which mouse button starts panning (Left / Middle / Right).">Pan with: Left</button>
+        <button id="viewPanButtonToggle" class="view-toggle-btn view-pan-with-btn" type="button" title="Choose which mouse button starts panning (Left / Middle / Right).">Pan with: Right</button>
       </div>
       <div class="view-controls-slider" title="Adjust how fast zooming responds to scroll or pinch.">
         <label for="viewZoomSensitivity">Zoom speed</label>

--- a/index.html
+++ b/index.html
@@ -301,6 +301,10 @@
           <option value="canvas2d">canvas2d</option>
         </select>
       </div>
+      <div class="display-options-row display-options-row--label-wide" title="Legacy mode: forces Canvas2D, reduces effects and frame rate to improve responsiveness on slow devices (e.g. old tablets).">
+        <label for="rendererLegacyMode" class="display-options-label-inline">Legacy mode (low‑performance devices)</label>
+        <input type="checkbox" id="rendererLegacyMode" class="display-options-checkbox" aria-label="Legacy mode for slow devices">
+      </div>
       <div class="display-options-slider renderer-mode-slider" title="Cap the render buffer resolution to improve performance. Layout; only the internal draw resolution is limited. Resolutions above 1080p can severely hinder performance, especially with animations.">
         <label for="puzzleResolutionSelect" title="Lower resolution uses fewer pixels for drawing and can reduce lag when dragging in fullscreen. Resolutions above 1080p can severely hinder performance, especially with animations.">Puzzle resolution</label>
         <select id="puzzleResolutionSelect" class="display-options-select" aria-label="Puzzle render resolution cap">

--- a/index.html
+++ b/index.html
@@ -317,6 +317,17 @@
           <option value="540p">540p</option>
         </select>
       </div>
+      <div class="display-options-slider renderer-mode-slider" title="Cap how often video or animated media frames are applied. Lower framerates reduce CPU/GPU load; Uncapped uses the source&#39;s native rate.">
+        <label for="videoFrameRateSelect" title="Video / animation framerate cap. Lower values improve performance on slow devices.">Video / animation framerate</label>
+        <select id="videoFrameRateSelect" class="display-options-select" aria-label="Video animation framerate cap">
+          <option value="0">Uncapped</option>
+          <option value="16">60 fps</option>
+          <option value="33" selected>30 fps</option>
+          <option value="42">24 fps</option>
+          <option value="50">20 fps</option>
+          <option value="66">15 fps</option>
+        </select>
+      </div>
       <div class="display-options-row display-options-row--label-wide" title="Show the puzzle image in grayscale behind the pieces as a reference while solving.">
         <label for="showGrayscaleReference" class="display-options-label-inline">Grayscale reference behind pieces</label>
         <input type="checkbox" id="showGrayscaleReference" class="display-options-checkbox" aria-label="Show grayscale reference image behind pieces">

--- a/index.html
+++ b/index.html
@@ -301,10 +301,14 @@
           <option value="canvas2d">canvas2d</option>
         </select>
       </div>
-      <div class="display-options-slider renderer-mode-slider" title="Cap the render buffer resolution to improve performance. Layout; only the internal draw resolution is limited.">
-        <label for="puzzleResolutionSelect" title="Lower resolution uses fewer pixels for drawing and can reduce lag when dragging in fullscreen.">Puzzle resolution</label>
+      <div class="display-options-slider renderer-mode-slider" title="Cap the render buffer resolution to improve performance. Layout; only the internal draw resolution is limited. Resolutions above 1080p can severely hinder performance, especially with animations.">
+        <label for="puzzleResolutionSelect" title="Lower resolution uses fewer pixels for drawing and can reduce lag when dragging in fullscreen. Resolutions above 1080p can severely hinder performance, especially with animations.">Puzzle resolution</label>
         <select id="puzzleResolutionSelect" class="display-options-select" aria-label="Puzzle render resolution cap">
-          <option value="1080p">1080p</option>
+          <option value="16k">16K</option>
+          <option value="8k">8K</option>
+          <option value="4k">4K</option>
+          <option value="1440p">1440p</option>
+          <option value="1080p" selected>1080p</option>
           <option value="720p">720p</option>
           <option value="540p">540p</option>
         </select>

--- a/index.html
+++ b/index.html
@@ -129,12 +129,26 @@
   <div class="changelog-modal-card">
     <div class="changelog-modal-title">Changelog</div>
     <div class="changelog-modal-subtitle">
-      Current changelog version: <span class="changelog-current-version">0.10.0</span>
+      Current changelog version: <span class="changelog-current-version">0.10.1</span>
     </div>
     <div class="changelog-modal-scroll">
       <div class="changelog-modal-intro">
         This changelog appears automatically when a new changelog version is detected and can always be reopened from the login page.
       </div>
+
+      <article class="changelog-entry">
+        <div class="changelog-entry-title">Version 0.10.1</div>
+        <div class="changelog-entry-body">
+          <ul>
+            <li><strong>Resolution &amp; display:</strong> Puzzle resolution now supports 1440p, 4K, 8K, and 16K (default stays 1080p). Higher resolutions can affect performance—a tooltip on the dropdown reminds you. The puzzle image uses more of the play area (90% instead of 85%) so pieces look a bit sharper. In Canvas2D, scaling looks better when resolution is capped; in WebGL, piece edges are crisper.</li>
+            <li><strong>Cleaner, consistent windows:</strong> Chat/Log, View controls, Cosmetic options, Piece drawer, and Load custom media all use the same compact header and layout. Less padding, smaller titles, and the same look everywhere. Chat can be resized shorter; only the content area scrolls. Load custom media opens in the right place and stays on top of other UI.</li>
+            <li><strong>Legacy mode for slower devices:</strong> A new “Legacy mode (low‑performance devices)” option in display settings uses a lighter rendering path (Canvas2D only, lower frame rate, no held‑piece shadow) so the game runs better on older tablets and slower PCs. When Legacy mode is on, WebGL is disabled until you turn it off; a short message explains this.</li>
+            <li><strong>Performance:</strong> Piece movement is smoother, piece picking is faster, and the piece you’re holding stays on top. Dropping a piece checks only nearby pieces for merges, so drops feel snappier. Resizing the window spreads redraws over several frames so the game stays responsive. The preview/sync window only redraws when it’s open. One animation loop instead of two and fewer things drawn each frame help on slower devices. Several console logs that could slow things down were removed.</li>
+            <li><strong>Video and animation:</strong> A new “Video / animation framerate” option (Cosmetics) lets you cap video/GIF updates at 60, 30, 24, 20, or 15 fps (default 30). Lower values reduce load on weaker devices. Video and GIF no longer push at full decode rate, so the game stays responsive. The grayscale reference behind pieces updates less often with video/GIF (about 8 times per second) to save work. Video and GIF now work correctly and more efficiently with both Canvas2D and WebGL.</li>
+            <li><strong>Cosmetic options:</strong> “Preview outline only” draws an outline around the puzzle preview so you can see the puzzle size without showing the full grayscale image. The outline follows the actual image area (including square pieces and other layouts).</li>
+          </ul>
+        </div>
+      </article>
 
       <article class="changelog-entry">
         <div class="changelog-entry-title">Version 0.10.0</div>

--- a/script.js
+++ b/script.js
@@ -2224,8 +2224,12 @@ function updateGrayscaleReferenceCanvas() {
         grayscaleReferenceCanvas.style.pointerEvents = "none";
         grayscaleReferenceCanvas.style.zIndex = "99999997";
     }
-    grayscaleReferenceCanvas.width = bufW;
-    grayscaleReferenceCanvas.height = bufH;
+    // Only resize when dimensions change; setting width/height clears the canvas and causes
+    // flicker when grayscale is throttled (video/camera) because we clear every frame but draw only every 120ms.
+    if (grayscaleReferenceCanvas.width !== bufW || grayscaleReferenceCanvas.height !== bufH) {
+        grayscaleReferenceCanvas.width = bufW;
+        grayscaleReferenceCanvas.height = bufH;
+    }
     grayscaleReferenceCanvas.style.width = w + "px";
     grayscaleReferenceCanvas.style.height = h + "px";
     grayscaleReferenceCanvas.style.left = (puzzle.offsx || 0) + "px";

--- a/script.js
+++ b/script.js
@@ -64,7 +64,7 @@ try {
 } catch (_e) {}
 try {
     const stored = localStorage.getItem("puzzleResolution");
-    if (stored === "1080p" || stored === "720p" || stored === "540p") {
+    if (stored === "16k" || stored === "8k" || stored === "4k" || stored === "1440p" || stored === "1080p" || stored === "720p" || stored === "540p") {
         viewState.puzzleResolution = stored;
     }
 } catch (_e) {}
@@ -3317,7 +3317,7 @@ if (window.JigsawRendererModeControl && typeof window.JigsawRendererModeControl.
         queuePolyPieceSetup: (...args) => queuePolyPieceSetup(...args),
         getPuzzleResolution: getPuzzleResolution,
         setPuzzleResolution: (value) => {
-            if (value === "1080p" || value === "720p" || value === "540p") {
+            if (value === "16k" || value === "8k" || value === "4k" || value === "1440p" || value === "1080p" || value === "720p" || value === "540p") {
                 viewState.puzzleResolution = value;
                 try { localStorage.setItem("puzzleResolution", value); } catch (_e) {}
             }

--- a/script.js
+++ b/script.js
@@ -64,6 +64,7 @@ const viewState = {
     puzzleResolution: "1080p",
     videoFrameIntervalMs: 33,
     showGrayscaleReference: false,
+    showPreviewOutline: false,
     useCustomDropLocation: false,
     customDropNormX: 0.1,
     customDropNormY: 0.1,
@@ -76,6 +77,10 @@ try {
 try {
     const storedRef = localStorage.getItem("showGrayscaleReference");
     if (storedRef === "true") viewState.showGrayscaleReference = true;
+} catch (_e) {}
+try {
+    const storedOutline = localStorage.getItem("showPreviewOutline");
+    if (storedOutline === "true") viewState.showPreviewOutline = true;
 } catch (_e) {}
 try {
     const stored = localStorage.getItem("puzzleResolution");
@@ -2101,7 +2106,7 @@ class Puzzle {
         if (!canvas2dWithVideo && !webglWithVideo) {
             this.renderSourceToGameCanvas(frameSource);
         }
-        if (viewState.showGrayscaleReference && typeof updateGrayscaleReferenceCanvas === "function") updateGrayscaleReferenceCanvas();
+        if ((viewState.showGrayscaleReference || viewState.showPreviewOutline) && typeof updateGrayscaleReferenceCanvas === "function") updateGrayscaleReferenceCanvas();
         if (activeRendererName !== "CanvasRenderer" && activeRendererName !== "WebGLRenderer") {
             for (const pp of this.polyPieces) pp.polypiece_drawImage(true);
         }
@@ -2191,9 +2196,13 @@ let grayscaleReferenceCtx = null;
 let lastGrayscaleUpdateMs = 0;
 const GRAYSCALE_VIDEO_INTERVAL_MS = 120;
 
+const PREVIEW_OUTLINE_STROKE_PX = 3;
+
 function updateGrayscaleReferenceCanvas() {
     if (!puzzle || !puzzle.container) return;
-    if (!viewState.showGrayscaleReference) {
+    const showGrayscale = !!viewState.showGrayscaleReference;
+    const showOutline = !!viewState.showPreviewOutline;
+    if (!showGrayscale && !showOutline) {
         if (grayscaleReferenceCanvas && grayscaleReferenceCanvas.parentNode) {
             grayscaleReferenceCanvas.parentNode.removeChild(grayscaleReferenceCanvas);
         }
@@ -2204,16 +2213,6 @@ function updateGrayscaleReferenceCanvas() {
     if (!puzzle.gameCanvas || !puzzle.gameCtx || typeof puzzle.gameWidth !== "number" || puzzle.gameWidth <= 0 || typeof puzzle.gameHeight !== "number" || puzzle.gameHeight <= 0) return;
     const w = Math.max(1, Math.round(puzzle.gameWidth));
     const h = Math.max(1, Math.round(puzzle.gameHeight));
-    const nowMs = (typeof performance !== "undefined" && performance.now) ? performance.now() : Date.now();
-    const frameSource = (typeof rendererFacade !== "undefined" && rendererFacade && rendererFacade.media && typeof rendererFacade.media.getFrameSource === "function") ? rendererFacade.media.getFrameSource() : null;
-    const mediaStatus = (typeof rendererFacade !== "undefined" && rendererFacade && rendererFacade.media && typeof rendererFacade.media.getStatus === "function") ? rendererFacade.media.getStatus() : null;
-    const kind = mediaStatus && mediaStatus.kind ? mediaStatus.kind : "image";
-    const isVideoSource = !!(frameSource && typeof frameSource.videoWidth === "number" && typeof frameSource.videoHeight === "number");
-    const isAnimated = isVideoSource || kind === "gif-decoded";
-    if (isAnimated && (nowMs - lastGrayscaleUpdateMs) < GRAYSCALE_VIDEO_INTERVAL_MS) {
-        return;
-    }
-    if (isAnimated) lastGrayscaleUpdateMs = nowMs;
     const halfRes = 2;
     const bufW = Math.max(1, Math.floor(w / halfRes));
     const bufH = Math.max(1, Math.floor(h / halfRes));
@@ -2232,22 +2231,57 @@ function updateGrayscaleReferenceCanvas() {
     grayscaleReferenceCanvas.style.left = (puzzle.offsx || 0) + "px";
     grayscaleReferenceCanvas.style.top = (puzzle.offsy || 0) + "px";
     if (!grayscaleReferenceCtx) return;
-    grayscaleReferenceCtx.filter = "grayscale(1) contrast(0.5)";
-    if (isVideoSource && frameSource && puzzle._gifDraw) {
-        const g = puzzle._gifDraw;
-        const vw = Math.max(1, frameSource.videoWidth || 1);
-        const vh = Math.max(1, frameSource.videoHeight || 1);
-        const dx = g.dx / halfRes;
-        const dy = g.dy / halfRes;
-        const dw = g.dw / halfRes;
-        const dh = g.dh / halfRes;
-        grayscaleReferenceCtx.drawImage(frameSource, 0, 0, vw, vh, dx, dy, dw, dh);
-    } else if (kind === "gif-decoded" && frameSource && typeof frameSource.width === "number" && typeof frameSource.height === "number") {
-        grayscaleReferenceCtx.drawImage(frameSource, 0, 0, frameSource.width, frameSource.height, 0, 0, bufW, bufH);
+
+    if (showGrayscale) {
+        const nowMs = (typeof performance !== "undefined" && performance.now) ? performance.now() : Date.now();
+        const frameSource = (typeof rendererFacade !== "undefined" && rendererFacade && rendererFacade.media && typeof rendererFacade.media.getFrameSource === "function") ? rendererFacade.media.getFrameSource() : null;
+        const mediaStatus = (typeof rendererFacade !== "undefined" && rendererFacade && rendererFacade.media && typeof rendererFacade.media.getStatus === "function") ? rendererFacade.media.getStatus() : null;
+        const kind = mediaStatus && mediaStatus.kind ? mediaStatus.kind : "image";
+        const isVideoSource = !!(frameSource && typeof frameSource.videoWidth === "number" && typeof frameSource.videoHeight === "number");
+        const isAnimated = isVideoSource || kind === "gif-decoded";
+        if (!isAnimated || (nowMs - lastGrayscaleUpdateMs) >= GRAYSCALE_VIDEO_INTERVAL_MS) {
+            if (isAnimated) lastGrayscaleUpdateMs = nowMs;
+            grayscaleReferenceCtx.filter = "grayscale(1) contrast(0.5)";
+            if (isVideoSource && frameSource && puzzle._gifDraw) {
+                const g = puzzle._gifDraw;
+                const vw = Math.max(1, frameSource.videoWidth || 1);
+                const vh = Math.max(1, frameSource.videoHeight || 1);
+                const dx = g.dx / halfRes;
+                const dy = g.dy / halfRes;
+                const dw = g.dw / halfRes;
+                const dh = g.dh / halfRes;
+                grayscaleReferenceCtx.drawImage(frameSource, 0, 0, vw, vh, dx, dy, dw, dh);
+            } else if (kind === "gif-decoded" && frameSource && typeof frameSource.width === "number" && typeof frameSource.height === "number") {
+                grayscaleReferenceCtx.drawImage(frameSource, 0, 0, frameSource.width, frameSource.height, 0, 0, bufW, bufH);
+            } else {
+                grayscaleReferenceCtx.drawImage(puzzle.gameCanvas, 0, 0, w, h, 0, 0, bufW, bufH);
+            }
+            grayscaleReferenceCtx.filter = "none";
+        }
     } else {
-        grayscaleReferenceCtx.drawImage(puzzle.gameCanvas, 0, 0, w, h, 0, 0, bufW, bufH);
+        grayscaleReferenceCtx.clearRect(0, 0, bufW, bufH);
     }
-    grayscaleReferenceCtx.filter = "none";
+
+    if (showOutline) {
+        const L = PREVIEW_OUTLINE_STROKE_PX;
+        grayscaleReferenceCtx.strokeStyle = "rgba(0,0,0,0.45)";
+        grayscaleReferenceCtx.lineWidth = L;
+        let ox, oy, ow, oh;
+        if (puzzle._gifDraw && typeof puzzle._gifDraw.dx === "number" && typeof puzzle._gifDraw.dw === "number") {
+            const g = puzzle._gifDraw;
+            ox = (g.dx || 0) / halfRes;
+            oy = (g.dy || 0) / halfRes;
+            ow = Math.min(g.dw, w) / halfRes;
+            oh = Math.min(g.dh, h) / halfRes;
+        } else {
+            ox = 0;
+            oy = 0;
+            ow = bufW;
+            oh = bufH;
+        }
+        grayscaleReferenceCtx.strokeRect(ox + L / 2, oy + L / 2, Math.max(0, ow - L), Math.max(0, oh - L));
+    }
+
     if (!grayscaleReferenceCanvas.parentNode) {
         puzzle.container.insertBefore(grayscaleReferenceCanvas, puzzle.container.firstChild);
     }

--- a/script.js
+++ b/script.js
@@ -3,7 +3,7 @@
 window.pieceSides = 4;
 const corner_to_shape_dist = 1/3; // distance from corner to shape in hexagonal piece
 
-window.downsize_to_fit = 0.85;
+window.downsize_to_fit = 0.9;
 window.PUZZLE_AREA_SURFACE_MULTIPLIER = 2;
 window.show_clue = true;
 window.rotations = 0;

--- a/script.js
+++ b/script.js
@@ -62,6 +62,7 @@ const viewState = {
     fitScaleLocked: null,
     isScalingLocked: false,
     puzzleResolution: "1080p",
+    videoFrameIntervalMs: 33,
     showGrayscaleReference: false,
     useCustomDropLocation: false,
     customDropNormX: 0.1,
@@ -80,6 +81,13 @@ try {
     const stored = localStorage.getItem("puzzleResolution");
     if (stored === "16k" || stored === "8k" || stored === "4k" || stored === "1440p" || stored === "1080p" || stored === "720p" || stored === "540p") {
         viewState.puzzleResolution = stored;
+    }
+} catch (_e) {}
+try {
+    const storedVideoFps = localStorage.getItem("videoFrameIntervalMs");
+    if (storedVideoFps !== null && storedVideoFps !== "") {
+        const ms = parseInt(storedVideoFps, 10);
+        if (!isNaN(ms) && ms >= 0) viewState.videoFrameIntervalMs = ms;
     }
 } catch (_e) {}
 try {
@@ -587,12 +595,18 @@ class PolyPiece {
         this.withdrawn = false;
         this.rot = 0;
 
-        this.polypiece_canvas = document.createElement('CANVAS');
-        // size and z-index will be defined later
-        puzzle.container.appendChild(this.polypiece_canvas);
-        this.polypiece_canvas.classList.add('polypiece');
-        this.polypiece_canvas.style.display = "none";
-        this.polypiece_ctx = this.polypiece_canvas.getContext("2d");
+        const overlayRendererActive = typeof rendererFacade !== "undefined" && rendererFacade && rendererFacade.activeRenderer &&
+            (rendererFacade.activeRenderer.constructor.name === "CanvasRenderer" || rendererFacade.activeRenderer.constructor.name === "WebGLRenderer");
+        if (overlayRendererActive) {
+            this.polypiece_canvas = null;
+            this.polypiece_ctx = null;
+        } else {
+            this.polypiece_canvas = document.createElement('CANVAS');
+            puzzle.container.appendChild(this.polypiece_canvas);
+            this.polypiece_canvas.classList.add('polypiece');
+            this.polypiece_canvas.style.display = "none";
+            this.polypiece_ctx = this.polypiece_canvas.getContext("2d");
+        }
     } // PolyPiece
 
     // -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -   -
@@ -702,7 +716,7 @@ class PolyPiece {
 
         queuePolyPieceSetup(this, !forceRedraw, true, () => {
             this.moveTo(targetX, targetY);
-            if (this.puzzle.container.contains(otherPoly.polypiece_canvas)) {
+            if (otherPoly.polypiece_canvas && this.puzzle.container.contains(otherPoly.polypiece_canvas)) {
                 this.puzzle.container.removeChild(otherPoly.polypiece_canvas);
             }
             this.puzzle.evaluateZIndex();
@@ -1022,11 +1036,11 @@ class PolyPiece {
         this.nx = this.pckxmax - this.pckxmin + 1;
         this.ny = this.pckymax - this.pckymin + 1;
 
-        if(!ignoreRedraw){
+        if (this.polypiece_canvas && !ignoreRedraw) {
             this.polypiece_canvas.width = this.nx * puzzle.scalex;  // make canvas big enough to fit all pieces
             this.polypiece_canvas.height = this.ny * puzzle.scaley;
         }
-        
+
 
         // difference between position in this canvas and position in gameImage
 
@@ -1090,19 +1104,21 @@ class PolyPiece {
 
         // In single-canvas 2D mode, keep per-piece canvases as overlay/path data only.
         // Other paths still draw media pixels into each piece canvas.
-        if (!canvas2dActive && !webglActive) {
+        if (!canvas2dActive && !webglActive && this.polypiece_ctx) {
             this._drawPiecePixelsFromGameCanvas(puzzle, srcx, srcy, destx, desty);
         }
 
-        // Keep only overlay/hit-test data on piece canvases for renderer-backed modes.
-        this.polypiece_canvas.style.backgroundImage = "none";
-        this.polypiece_canvas.style.maskImage = "none";
-        this.polypiece_canvas.style.webkitMaskImage = "none";
-        this._drawOverlayOnly(puzzle, canvas2dActive || webglActive);
         this._overlayVersion = (this._overlayVersion || 0) + 1;
-        if (webglActive) this._ensureWebGLMaskCanvas();
+        if (this.polypiece_canvas) {
+            // Keep only overlay/hit-test data on piece canvases for renderer-backed modes.
+            this.polypiece_canvas.style.backgroundImage = "none";
+            this.polypiece_canvas.style.maskImage = "none";
+            this.polypiece_canvas.style.webkitMaskImage = "none";
+            this._drawOverlayOnly(puzzle, canvas2dActive || webglActive);
+            if (webglActive) this._ensureWebGLMaskCanvas();
+            this.polypiece_canvas.style.display = rendererReady ? "none" : "block";
+        }
         if (rendererFacade && rendererFacade.sceneState) rendererFacade.sceneState.markPieceDirty(this);
-        this.polypiece_canvas.style.display = rendererReady ? "none" : "block";
         return;
 
     } // PolyPiece.polypiece_drawImage
@@ -1127,6 +1143,7 @@ class PolyPiece {
     }
 
     _drawOverlayOnly(puz, clearCanvas = true) {
+        if (!this.polypiece_ctx || !this.polypiece_canvas) return;
         this.polypiece_ctx.setTransform(1, 0, 0, 1, 0, 0);
         if (clearCanvas) {
             this.polypiece_ctx.clearRect(0, 0, this.polypiece_canvas.width, this.polypiece_canvas.height);
@@ -1172,6 +1189,49 @@ class PolyPiece {
         }
     }
 
+    /** Draw overlay (borders + hint) to an arbitrary 2D context. ctx must already be in piece-local space (0,0) to (w,h); do not reset transform. Caller may clear first if needed. */
+    drawOverlayToContext(ctx, w, h, puz) {
+        if (!ctx || !this.path) return;
+        const borders = apnx * apny < 150 && bevel_size > 0;
+        const embth = puz.scalex * 0.01 * bevel_size;
+        const worldLight = this._worldToPieceLocal(embth / 2, -embth / 2);
+
+        if (borders) {
+            this.pieces.forEach((pp, kk) => {
+                ctx.save();
+
+                const path = new Path2D();
+                const shiftx = -this.offsx;
+                const shifty = -this.offsy;
+                pp.sides.forEach((side, i) => {
+                    if (i === 0) {
+                        side.drawPath(path, shiftx, shifty, false);
+                    } else {
+                        side.drawPath(path, shiftx, shifty, true);
+                    }
+                });
+                path.closePath();
+
+                ctx.clip(path);
+                ctx.translate(worldLight.x, worldLight.y);
+                ctx.lineWidth = embth;
+                ctx.strokeStyle = "rgba(0, 0, 0, 0.35)";
+                ctx.stroke(path);
+                ctx.translate(-2 * worldLight.x, -2 * worldLight.y);
+                ctx.strokeStyle = "rgba(255, 255, 255, 0.35)";
+                ctx.stroke(path);
+
+                ctx.restore();
+            });
+        }
+
+        if (this.hinted) {
+            ctx.strokeStyle = hint_color;
+            ctx.lineWidth = Math.max(0.03 * puz.scalex, 7);
+            ctx.stroke(this.path);
+        }
+    }
+
     _worldToPieceLocal(worldDx, worldDy) {
         const deg = (window.rotations === 180 ? 90 : window.rotations) || 0;
         const angle = (this.rot || 0) * deg * Math.PI / 180;
@@ -1184,6 +1244,7 @@ class PolyPiece {
     }
 
     _ensureWebGLMaskCanvas() {
+        if (!this.polypiece_canvas) return;
         const w = this.polypiece_canvas.width | 0;
         const h = this.polypiece_canvas.height | 0;
         if (w <= 0 || h <= 0 || !this.path) return;
@@ -1201,6 +1262,7 @@ class PolyPiece {
     }
 
     _applyPieceTransform() {
+        if (!this.polypiece_canvas) return;
         const el = this.polypiece_canvas;
         el.style.left = "0";
         el.style.top = "0";
@@ -1262,8 +1324,10 @@ class PolyPiece {
 
         if(moving){
             // Adjust position to ensure the piece stays under the cursor
-            const centerX = this.x + (this.polypiece_canvas.width / 2);
-            const centerY = this.y + (this.polypiece_canvas.height / 2);
+            const pw = this.polypiece_canvas ? this.polypiece_canvas.width : (this.nx * this.puzzle.scalex);
+            const ph = this.polypiece_canvas ? this.polypiece_canvas.height : (this.ny * this.puzzle.scaley);
+            const centerX = this.x + (pw / 2);
+            const centerY = this.y + (ph / 2);
 
             const offsetX = moving.xMouse - centerX;
             const offsetY = moving.yMouse - centerY;
@@ -2004,11 +2068,11 @@ class Puzzle {
             if (rendererFacade && rendererFacade.sceneState) rendererFacade.sceneState.markZOrderDirty();
             return;
         }
-        // re-assign zIndex (numeric on piece for sort cache, style for DOM)
+        // re-assign zIndex
         this.polyPieces.forEach((pp, k) => {
             const z = -pp.pieces.length * 10000 + k + 100000000;
             pp._zIndex = z;
-            pp.polypiece_canvas.style.zIndex = z;
+            if (pp.polypiece_canvas) pp.polypiece_canvas.style.zIndex = z;
         });
         this._zOrderVersion = (this._zOrderVersion || 0) + 1;
         this._sortedPolyPiecesByZ = this.polyPieces.slice();
@@ -2028,11 +2092,16 @@ class Puzzle {
 
       applyMediaFrame(frameSource, nowMs) {
         if (!frameSource || !this.polyPieces || !this.polyPieces.length) return false;
-        this.renderSourceToGameCanvas(frameSource);
-        if (viewState.showGrayscaleReference && typeof updateGrayscaleReferenceCanvas === "function") updateGrayscaleReferenceCanvas();
         const activeRendererName = (rendererFacade && rendererFacade.activeRenderer && rendererFacade.activeRenderer.constructor)
             ? rendererFacade.activeRenderer.constructor.name
             : "";
+        const isVideo = !!(frameSource && typeof frameSource.videoWidth === "number");
+        const canvas2dWithVideo = activeRendererName === "CanvasRenderer" && isVideo;
+        const webglWithVideo = activeRendererName === "WebGLRenderer" && isVideo;
+        if (!canvas2dWithVideo && !webglWithVideo) {
+            this.renderSourceToGameCanvas(frameSource);
+        }
+        if (viewState.showGrayscaleReference && typeof updateGrayscaleReferenceCanvas === "function") updateGrayscaleReferenceCanvas();
         if (activeRendererName !== "CanvasRenderer" && activeRendererName !== "WebGLRenderer") {
             for (const pp of this.polyPieces) pp.polypiece_drawImage(true);
         }
@@ -2116,8 +2185,11 @@ let tmpImage;
 let tmpPreviewCtx = null;
 let syncedPreviewCanvas = null;
 let syncedPreviewCtx = null;
+let lastSyncedPreviewAt = 0;
 let grayscaleReferenceCanvas = null;
 let grayscaleReferenceCtx = null;
+let lastGrayscaleUpdateMs = 0;
+const GRAYSCALE_VIDEO_INTERVAL_MS = 120;
 
 function updateGrayscaleReferenceCanvas() {
     if (!puzzle || !puzzle.container) return;
@@ -2132,6 +2204,19 @@ function updateGrayscaleReferenceCanvas() {
     if (!puzzle.gameCanvas || !puzzle.gameCtx || typeof puzzle.gameWidth !== "number" || puzzle.gameWidth <= 0 || typeof puzzle.gameHeight !== "number" || puzzle.gameHeight <= 0) return;
     const w = Math.max(1, Math.round(puzzle.gameWidth));
     const h = Math.max(1, Math.round(puzzle.gameHeight));
+    const nowMs = (typeof performance !== "undefined" && performance.now) ? performance.now() : Date.now();
+    const frameSource = (typeof rendererFacade !== "undefined" && rendererFacade && rendererFacade.media && typeof rendererFacade.media.getFrameSource === "function") ? rendererFacade.media.getFrameSource() : null;
+    const mediaStatus = (typeof rendererFacade !== "undefined" && rendererFacade && rendererFacade.media && typeof rendererFacade.media.getStatus === "function") ? rendererFacade.media.getStatus() : null;
+    const kind = mediaStatus && mediaStatus.kind ? mediaStatus.kind : "image";
+    const isVideoSource = !!(frameSource && typeof frameSource.videoWidth === "number" && typeof frameSource.videoHeight === "number");
+    const isAnimated = isVideoSource || kind === "gif-decoded";
+    if (isAnimated && (nowMs - lastGrayscaleUpdateMs) < GRAYSCALE_VIDEO_INTERVAL_MS) {
+        return;
+    }
+    if (isAnimated) lastGrayscaleUpdateMs = nowMs;
+    const halfRes = 2;
+    const bufW = Math.max(1, Math.floor(w / halfRes));
+    const bufH = Math.max(1, Math.floor(h / halfRes));
     if (!grayscaleReferenceCanvas) {
         grayscaleReferenceCanvas = document.createElement("canvas");
         grayscaleReferenceCtx = grayscaleReferenceCanvas.getContext("2d");
@@ -2140,15 +2225,28 @@ function updateGrayscaleReferenceCanvas() {
         grayscaleReferenceCanvas.style.pointerEvents = "none";
         grayscaleReferenceCanvas.style.zIndex = "99999997";
     }
-    grayscaleReferenceCanvas.width = w;
-    grayscaleReferenceCanvas.height = h;
+    grayscaleReferenceCanvas.width = bufW;
+    grayscaleReferenceCanvas.height = bufH;
     grayscaleReferenceCanvas.style.width = w + "px";
     grayscaleReferenceCanvas.style.height = h + "px";
     grayscaleReferenceCanvas.style.left = (puzzle.offsx || 0) + "px";
     grayscaleReferenceCanvas.style.top = (puzzle.offsy || 0) + "px";
     if (!grayscaleReferenceCtx) return;
     grayscaleReferenceCtx.filter = "grayscale(1) contrast(0.5)";
-    grayscaleReferenceCtx.drawImage(puzzle.gameCanvas, 0, 0, w, h, 0, 0, w, h);
+    if (isVideoSource && frameSource && puzzle._gifDraw) {
+        const g = puzzle._gifDraw;
+        const vw = Math.max(1, frameSource.videoWidth || 1);
+        const vh = Math.max(1, frameSource.videoHeight || 1);
+        const dx = g.dx / halfRes;
+        const dy = g.dy / halfRes;
+        const dw = g.dw / halfRes;
+        const dh = g.dh / halfRes;
+        grayscaleReferenceCtx.drawImage(frameSource, 0, 0, vw, vh, dx, dy, dw, dh);
+    } else if (kind === "gif-decoded" && frameSource && typeof frameSource.width === "number" && typeof frameSource.height === "number") {
+        grayscaleReferenceCtx.drawImage(frameSource, 0, 0, frameSource.width, frameSource.height, 0, 0, bufW, bufH);
+    } else {
+        grayscaleReferenceCtx.drawImage(puzzle.gameCanvas, 0, 0, w, h, 0, 0, bufW, bufH);
+    }
     grayscaleReferenceCtx.filter = "none";
     if (!grayscaleReferenceCanvas.parentNode) {
         puzzle.container.insertBefore(grayscaleReferenceCanvas, puzzle.container.firstChild);
@@ -2378,12 +2476,14 @@ document.addEventListener("gestureend", preventZoomWhileHoldingPiece, { passive:
     const HELD_Z_INDEX = 2147483647;
 
     function setHeldPieceState(pp, held) {
-        if (!pp || !pp.polypiece_canvas) return;
+        if (!pp) return;
         pp._isHeld = !!held;
-        pp.polypiece_canvas.classList.toggle("moving", !!held);
+        if (pp.polypiece_canvas) {
+            pp.polypiece_canvas.classList.toggle("moving", !!held);
+            if (held) pp.polypiece_canvas.style.zIndex = HELD_Z_INDEX;
+        }
         if (held) {
             pp._zIndex = HELD_Z_INDEX;
-            pp.polypiece_canvas.style.zIndex = HELD_Z_INDEX;
             puzzle._zOrderVersion = (puzzle._zOrderVersion || 0) + 1;
         }
         queuePolyPieceSetup(pp, true, true);
@@ -2395,7 +2495,13 @@ document.addEventListener("gestureend", preventZoomWhileHoldingPiece, { passive:
         const nowMs = (typeof performance !== "undefined" && performance.now) ? performance.now() : Date.now();
         if (rendererFacade) rendererFacade.renderFrame(nowMs);
         if (pieceSetupQueueApi && pieceSetupQueueApi.processPieceSetupQueue) pieceSetupQueueApi.processPieceSetupQueue();
-        if (!(window.rendererConfig && window.rendererConfig.legacyMode)) drawSyncedPreviewWindowFrame();
+        if (!(window.rendererConfig && window.rendererConfig.legacyMode)) {
+            const previewIntervalMs = (rendererFacade && rendererFacade.scheduler) ? rendererFacade.scheduler.targetFrameMs : 16;
+            if (nowMs - lastSyncedPreviewAt >= previewIntervalMs) {
+                drawSyncedPreviewWindowFrame();
+                lastSyncedPreviewAt = nowMs;
+            }
+        }
         if (state === 15) drawPrestartPreviewFrame();
         if (state >= 50 && puzzle && typeof updateDropLocationTarget === "function") updateDropLocationTarget();
 
@@ -3312,6 +3418,9 @@ if (window.JigsawRendererFacade) {
         getPuzzleResolution: getPuzzleResolution
     });
     rendererFacade.init(puzzle);
+    if (rendererFacade.media && typeof viewState.videoFrameIntervalMs === "number") {
+        rendererFacade.media.frameIntervalMs = viewState.videoFrameIntervalMs;
+    }
     hitTestService = rendererFacade.hitTest || null;
 } else if (window.JigsawHitTestService) {
     hitTestService = new window.JigsawHitTestService();

--- a/script.js
+++ b/script.js
@@ -12,8 +12,12 @@ window.rendererConfig = {
     mode: "auto", // canvas2d | webgl | auto
     media: "image", // image | gif | video | camera
     autoFallback: true,
-    perfBudgetMs: 8
+    perfBudgetMs: 8,
+    legacyMode: false // true = canvas2d, lower FPS, no/simple shadow, no preview sync
 };
+try {
+    if (typeof localStorage !== "undefined" && localStorage.getItem("rendererLegacyMode") === "true") window.rendererConfig.legacyMode = true;
+} catch (_e) {}
 
 var accept_pending_actions = false;
 var process_pending_actions = false;
@@ -29,6 +33,16 @@ Object.defineProperty(window.jigsawRuntime, "processPendingActions", {
 
 var bevel_size = localStorage.getItem("option_bevel_2");
 if (bevel_size === null) bevel_size = 0.1;
+
+/** Fisher-Yates in-place shuffle for uniform random order. */
+function shuffleArray(arr) {
+    for (let i = arr.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        const t = arr[i];
+        arr[i] = arr[j];
+        arr[j] = t;
+    }
+}
 
 // View/cosmetic control wiring is initialized later by src/ui/ViewControls.js.
 
@@ -1186,12 +1200,18 @@ class PolyPiece {
         this._maskVersion = (this._maskVersion || 0) + 1;
     }
 
+    _applyPieceTransform() {
+        const el = this.polypiece_canvas;
+        el.style.left = "0";
+        el.style.top = "0";
+        const rotamount = (window.rotations === 180) ? 90 : (window.rotations || 0);
+        el.style.transform = `translate(${this.x}px, ${this.y}px) rotate(${(this.rot || 0) * rotamount}deg)`;
+    }
+
     moveTo(x, y) {
-        // sets the left, top properties (relative to container) of this.canvas
         this.x = x;
         this.y = y;
-        this.polypiece_canvas.style.left = (this.x) + 'px';
-        this.polypiece_canvas.style.top = (this.y) + 'px';
+        this._applyPieceTransform();
         if (rendererFacade && rendererFacade.sceneState) rendererFacade.sceneState.markPieceDirty(this);
     } //
 
@@ -1237,12 +1257,7 @@ class PolyPiece {
             num_rots = 4;
         }
         this.rot = ((this.rot + increase + num_rots) % num_rots) | 0;
-        const currentTransform = this.polypiece_canvas.style.transform.replace(/rotate\([-\d.]+deg\)/, '');
-        let rotamount = window.rotations;
-        if(window.rotations == 180){
-            rotamount = 90;
-        }
-        this.polypiece_canvas.style.transform = `${currentTransform} rotate(${this.rot * rotamount}deg)`;
+        this._applyPieceTransform();
         if (rendererFacade && rendererFacade.sceneState) rendererFacade.sceneState.markPieceDirty(this);
 
         if(moving){
@@ -1411,7 +1426,7 @@ class Puzzle {
         /* dimensions of container */
         this.contWidth = parseFloat(styl.width);
         this.contHeight = parseFloat(styl.height);
-        
+        if (this._invalidateViewMetricsCache) this._invalidateViewMetricsCache();
     }
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1940,10 +1955,16 @@ class Puzzle {
     } // Puzzle.refreshConnectionDistance
 
     getViewMetrics() {
+        if (this._viewMetricsCache) return this._viewMetricsCache;
         const br = this.container.getBoundingClientRect();
         const baseScale = getActiveBaseScale();
         const effectiveScale = baseScale * viewState.zoom;
-        return { br, baseScale, effectiveScale };
+        this._viewMetricsCache = { br, baseScale, effectiveScale };
+        return this._viewMetricsCache;
+    }
+
+    _invalidateViewMetricsCache() {
+        this._viewMetricsCache = null;
     }
 
     screenToPuzzle(clientX, clientY) {
@@ -1979,15 +2000,20 @@ class Puzzle {
     evaluateZIndex() {
         if (!Array.isArray(this.polyPieces) || this.polyPieces.length === 0) {
             this._zOrderVersion = (this._zOrderVersion || 0) + 1;
-            if (rendererFacade && rendererFacade.sceneState) rendererFacade.sceneState.markAllDirty();
+            this._sortedPolyPiecesByZ = [];
+            if (rendererFacade && rendererFacade.sceneState) rendererFacade.sceneState.markZOrderDirty();
             return;
         }
-        // re-assign zIndex
+        // re-assign zIndex (numeric on piece for sort cache, style for DOM)
         this.polyPieces.forEach((pp, k) => {
-            pp.polypiece_canvas.style.zIndex = -pp.pieces.length * 10000 + k + 100000000;
+            const z = -pp.pieces.length * 10000 + k + 100000000;
+            pp._zIndex = z;
+            pp.polypiece_canvas.style.zIndex = z;
         });
         this._zOrderVersion = (this._zOrderVersion || 0) + 1;
-        if (rendererFacade && rendererFacade.sceneState) rendererFacade.sceneState.markAllDirty();
+        this._sortedPolyPiecesByZ = this.polyPieces.slice();
+        this._sortedPolyPiecesVersion = this._zOrderVersion;
+        if (rendererFacade && rendererFacade.sceneState) rendererFacade.sceneState.markZOrderDirty();
     } // Puzzle.evaluateZIndex
 
     renderSourceToGameCanvas(sourceOverride = null) {
@@ -2237,6 +2263,8 @@ function drawSyncedPreviewWindowFrame() {
         syncedPreviewCtx = syncedPreviewCanvas.getContext("2d");
     }
     if (!syncedPreviewCtx) return;
+    const parent = syncedPreviewCanvas.parentElement;
+    if (parent && parent.style && parent.style.display === "none") return;
     const source = resolvePrestartPreviewSource();
     if (!source) return;
     if (source.tagName === "VIDEO" && source.readyState < 2) return;
@@ -2354,6 +2382,7 @@ document.addEventListener("gestureend", preventZoomWhileHoldingPiece, { passive:
         pp._isHeld = !!held;
         pp.polypiece_canvas.classList.toggle("moving", !!held);
         if (held) {
+            pp._zIndex = HELD_Z_INDEX;
             pp.polypiece_canvas.style.zIndex = HELD_Z_INDEX;
             puzzle._zOrderVersion = (puzzle._zOrderVersion || 0) + 1;
         }
@@ -2365,7 +2394,8 @@ document.addEventListener("gestureend", preventZoomWhileHoldingPiece, { passive:
         requestAnimationFrame(animate);
         const nowMs = (typeof performance !== "undefined" && performance.now) ? performance.now() : Date.now();
         if (rendererFacade) rendererFacade.renderFrame(nowMs);
-        drawSyncedPreviewWindowFrame();
+        if (pieceSetupQueueApi && pieceSetupQueueApi.processPieceSetupQueue) pieceSetupQueueApi.processPieceSetupQueue();
+        if (!(window.rendererConfig && window.rendererConfig.legacyMode)) drawSyncedPreviewWindowFrame();
         if (state === 15) drawPrestartPreviewFrame();
         if (state >= 50 && puzzle && typeof updateDropLocationTarget === "function") updateDropLocationTarget();
 
@@ -2412,19 +2442,11 @@ document.addEventListener("gestureend", preventZoomWhileHoldingPiece, { passive:
                 const x_change = puzzle.contWidth / puzzle.prevWidth;
                 const y_change = puzzle.contHeight / puzzle.prevHeight;
 
-                console.log("start scaling pieces")
-                puzzle.polyPieces.forEach(pp => {                    
-                    let nnx = pp.x;
-                    let nny = pp.y;
-
-                    pp.moveTo(nnx, nny);
-                    pp.polypiece_drawImage(false);
-
-
+                puzzle.polyPieces.forEach(pp => {
                     pp.moveTo(pp.x * x_change, pp.y * y_change);
-
-                }); // puzzle.polypieces.forEach
-                console.log("end scaling pieces")
+                    queuePolyPieceSetup(pp, false, false);
+                });
+                if (rendererFacade && rendererFacade.sceneState) rendererFacade.sceneState.markAllDirty();
             }
             
             puzzle.prevWidth = puzzle.contWidth;
@@ -2802,8 +2824,8 @@ document.addEventListener("gestureend", preventZoomWhileHoldingPiece, { passive:
                 break;
 
             case 40: // evaluate z index
-                
-                puzzle.polyPieces.sort((a, b) => Math.random() - 0.5);
+
+                shuffleArray(puzzle.polyPieces);
                 puzzle.evaluateZIndex();
                 state = 45;
 
@@ -2830,7 +2852,6 @@ document.addEventListener("gestureend", preventZoomWhileHoldingPiece, { passive:
                 
                 if (event.event != "touch") return;
 
-                console.log(event)
                 if(event.button == 0){
                     const event_x = event.position.x;
                     const event_y = event.position.y;
@@ -2844,25 +2865,9 @@ document.addEventListener("gestureend", preventZoomWhileHoldingPiece, { passive:
                     });
     
                     /* evaluates if contact inside a PolyPiece, by decreasing z-index */
-                    let hitPiece = null;
-                    if (rendererFacade) {
-                        hitPiece = rendererFacade.findTopPieceAt(puzzle, event_x, event_y);
-                    } else if (hitTestService) {
-                        hitPiece = hitTestService.findTopPieceAt(puzzle, event_x, event_y);
-                    }
-                    if (!hitPiece) {
-                        puzzle.polyPieces.sort((a, b) => a.polypiece_canvas.style.zIndex - b.polypiece_canvas.style.zIndex);
-                        for (let k = puzzle.polyPieces.length-1; k >= 0; k--) {
-                            let pp = puzzle.polyPieces[k];
-                            const cx = pp.x + pp.nx * puzzle.scalex / 2;
-                            const cy = pp.y + pp.ny * puzzle.scaley / 2;
-                            const roxy = rotateVector(event_x - cx, event_y - cy, pp.rot);
-                            if (pp.path && pp.polypiece_ctx.isPointInPath(pp.path, cx + roxy.x - pp.x, cy + roxy.y - pp.y)) {
-                                hitPiece = pp;
-                                break;
-                            }
-                        }
-                    }
+                    const hitPiece = rendererFacade
+                        ? rendererFacade.findTopPieceAt(puzzle, event_x, event_y)
+                        : (hitTestService && hitTestService.findTopPieceAt(puzzle, event_x, event_y));
                     if (hitPiece) {
                         const hitIndex = puzzle.polyPieces.indexOf(hitPiece);
                         moving.pp = hitPiece;
@@ -2959,14 +2964,20 @@ document.addEventListener("gestureend", preventZoomWhileHoldingPiece, { passive:
                     case "leave":
                         // check if moved polypiece is close to a matching other polypiece
                         // check repeatedly since polypieces moved by merging may come close to other polypieces
+                        const m = moving.pp;
+                        const mRot = rotateVector(m.x + m.nx * puzzle.scalex / 2, m.y + m.ny * puzzle.scaley / 2, m.rot);
+                        const mx = mRot.x - puzzle.scalex * (m.pckxmax + m.pckxmin) / 2;
+                        const my = mRot.y - puzzle.scaley * (m.pckymax + m.pckymin) / 2;
 
                         for (let k = puzzle.polyPieces.length - 1; k >= 0; --k) {
-                            // console.log(k)
                             let pp = puzzle.polyPieces[k];
-                            if (pp == moving.pp || pp.pieces[0].index < 0 || moving.pp.pieces[0].index < 0) continue; // don't match with myself
-                            if (moving.pp.ifNear(pp)) { // a match !
+                            if (pp === m || pp.pieces[0].index < 0 || m.pieces[0].index < 0) continue; // don't match with myself
+                            const ppRot = rotateVector(pp.x + pp.nx * puzzle.scalex / 2, pp.y + pp.ny * puzzle.scaley / 2, pp.rot);
+                            const ppx = ppRot.x - puzzle.scalex * (pp.pckxmax + pp.pckxmin) / 2;
+                            const ppy = ppRot.y - puzzle.scaley * (pp.pckymax + pp.pckymin) / 2;
+                            if (((mx - ppx) ** 2 + (my - ppy) ** 2) >= puzzle.dConnect) continue;
+                            if (m.ifNear(pp)) { // a match !
                                 // compare polypieces sizes to move smallest one
-                                console.log("found something!")
                                 if (pp.pieces.length > moving.pp.pieces.length || (pp.pieces.length == moving.pp.pieces.length && pp.pieces[0].index > moving.pp.pieces[0].index)) {
                                     pp.merge(moving.pp);
                                     moving.pp = pp; // memorize piece to follow
@@ -2975,7 +2986,6 @@ document.addEventListener("gestureend", preventZoomWhileHoldingPiece, { passive:
                                     moving.pp.merge(pp);
                                     setHeldPieceState(moving.pp, true);
                                 }
-                                console.log("done merging")
                             }
                         } // for k
 
@@ -3338,7 +3348,7 @@ if (window.JigsawPieceSetupQueue && typeof window.JigsawPieceSetupQueue.create =
         getRendererConfig: () => window.rendererConfig,
         getRendererFacade: () => rendererFacade
     });
-    pieceSetupQueueApi.startLoop();
+    // Queue is driven from animate() to avoid a second requestAnimationFrame loop.
 }
 
 function queuePolyPieceSetup(pp, ignoreRedraw = false, highPriority = false, onDone = null) {

--- a/script.js
+++ b/script.js
@@ -58,7 +58,7 @@ const viewState = {
     zoomStep: 1.2,
     zoomSensitivity: 1,
     panSensitivity: 1,
-    panButton: 0,
+    panButton: 2,
     fitScaleLocked: null,
     isScalingLocked: false,
     puzzleResolution: "1080p",

--- a/src/core/HitTestService.js
+++ b/src/core/HitTestService.js
@@ -1,6 +1,21 @@
 "use strict";
 
 (function initHitTestService(globalScope) {
+    let sharedHitTestCanvas = null;
+    let sharedHitTestCtx = null;
+
+    function getSharedHitTestContext() {
+        if (!sharedHitTestCtx) {
+            sharedHitTestCanvas = typeof document !== "undefined" && document.createElement("canvas");
+            if (sharedHitTestCanvas) {
+                sharedHitTestCanvas.width = 1;
+                sharedHitTestCanvas.height = 1;
+                sharedHitTestCtx = sharedHitTestCanvas.getContext("2d");
+            }
+        }
+        return sharedHitTestCtx;
+    }
+
     class HitTestService {
         findTopPieceAt(puzzle, eventX, eventY) {
             if (!puzzle || !puzzle.polyPieces || !puzzle.polyPieces.length) return null;
@@ -16,15 +31,19 @@
                     return za - zb;
                 });
 
+            const ctx = getSharedHitTestContext();
             for (let k = sorted.length - 1; k >= 0; k--) {
                 const pp = sorted[k];
-                if (!pp.path || !pp.polypiece_ctx) continue;
+                if (!pp.path) continue;
                 const cx = pp.x + pp.nx * puzzle.scalex / 2;
                 const cy = pp.y + pp.ny * puzzle.scaley / 2;
                 const roxy = rotateVector(eventX - cx, eventY - cy, pp.rot);
-                if (pp.polypiece_ctx.isPointInPath(pp.path, cx + roxy.x - pp.x, cy + roxy.y - pp.y)) {
-                    return pp;
-                }
+                const localX = cx + roxy.x - pp.x;
+                const localY = cy + roxy.y - pp.y;
+                const hit = pp.polypiece_ctx
+                    ? pp.polypiece_ctx.isPointInPath(pp.path, localX, localY)
+                    : (ctx && ctx.isPointInPath(pp.path, localX, localY));
+                if (hit) return pp;
             }
             return null;
         }

--- a/src/core/HitTestService.js
+++ b/src/core/HitTestService.js
@@ -5,10 +5,16 @@
         findTopPieceAt(puzzle, eventX, eventY) {
             if (!puzzle || !puzzle.polyPieces || !puzzle.polyPieces.length) return null;
 
-            // Preserve existing behavior: highest z-index first.
-            const sorted = puzzle.polyPieces
+            const version = puzzle._zOrderVersion || 0;
+            const useCache = puzzle._sortedPolyPiecesByZ && puzzle._sortedPolyPiecesVersion === version
+                && puzzle._sortedPolyPiecesByZ.length === puzzle.polyPieces.length;
+            const sorted = useCache ? puzzle._sortedPolyPiecesByZ : puzzle.polyPieces
                 .slice()
-                .sort((a, b) => a.polypiece_canvas.style.zIndex - b.polypiece_canvas.style.zIndex);
+                .sort((a, b) => {
+                    const za = (a._zIndex != null) ? a._zIndex : (Number(a.polypiece_canvas && a.polypiece_canvas.style.zIndex) || 0);
+                    const zb = (b._zIndex != null) ? b._zIndex : (Number(b.polypiece_canvas && b.polypiece_canvas.style.zIndex) || 0);
+                    return za - zb;
+                });
 
             for (let k = sorted.length - 1; k >= 0; k--) {
                 const pp = sorted[k];

--- a/src/core/PuzzleSceneState.js
+++ b/src/core/PuzzleSceneState.js
@@ -8,6 +8,7 @@
             this.dirtyRects = [];
             this.version = 0;
             this.mediaContentDirty = true;
+            this.zOrderDirty = false;
         }
 
         bindPuzzle(puzzle) {
@@ -29,14 +30,19 @@
             this.version++;
         }
 
+        markZOrderDirty() {
+            this.zOrderDirty = true;
+            this.version++;
+        }
+
         consumeDirtyPieces() {
-            const out = Array.from(this.dirtyPieces);
             this.dirtyPieces.clear();
-            return out;
+            this.zOrderDirty = false;
+            this.version++;
         }
 
         hasDirtyPieces() {
-            return this.dirtyPieces.size > 0;
+            return this.dirtyPieces.size > 0 || this.zOrderDirty;
         }
 
         dirtyPieceCount() {

--- a/src/media/MediaSourceAdapter.js
+++ b/src/media/MediaSourceAdapter.js
@@ -205,13 +205,15 @@
                     return false;
                 }
                 const changed = this.lastVideoTime < 0 || v.currentTime !== this.lastVideoTime;
-                if (changed) {
-                    this.lastVideoTime = v.currentTime;
-                    this.lastFrameAt = nowMs;
-                    this.failureReason = "";
-                    return true;
+                if (!changed) return false;
+                const interval = this.frameIntervalMs || 0;
+                if (interval > 0 && this.lastFrameAt > 0 && (nowMs - this.lastFrameAt) < interval) {
+                    return false;
                 }
-                return false;
+                this.lastVideoTime = v.currentTime;
+                this.lastFrameAt = nowMs;
+                this.failureReason = "";
+                return true;
             }
 
             return false;

--- a/src/render/RendererFacade.js
+++ b/src/render/RendererFacade.js
@@ -342,7 +342,7 @@
                     this.modeNote = mediaStatus.failureReason;
                     this._emitStatusChange();
                 }
-                if (advanced) {
+                if (advanced && this.scheduler.shouldRender(nowMs)) {
                     const frameSource = this.media.getFrameSource();
                     if (frameSource && puzzle.applyMediaFrame && puzzle.applyMediaFrame(frameSource, nowMs)) {
                         this.sceneState.markAllDirty();
@@ -351,6 +351,19 @@
                 }
             }
             if (!this.scheduler.shouldRender(nowMs)) return;
+
+            if (this.media && puzzle && !mediaAdvanced) {
+                const status = this.media.getStatus ? this.media.getStatus() : null;
+                const kind = status && status.kind ? status.kind : "image";
+                const animated = kind === "video" || kind === "camera" || kind === "display" || kind === "gif-decoded";
+                if (animated) {
+                    const frameSource = this.media.getFrameSource();
+                    if (frameSource && puzzle.applyMediaFrame && puzzle.applyMediaFrame(frameSource, nowMs)) {
+                        this.sceneState.markAllDirty();
+                        mediaAdvanced = true;
+                    }
+                }
+            }
 
             // Catch WebGL failures before dirty-skip can short-circuit fallback.
             if (this._isWebGLRuntimeFailed()) {

--- a/src/render/RendererFacade.js
+++ b/src/render/RendererFacade.js
@@ -281,7 +281,11 @@
                 return { cappedW: Math.max(1, Math.round(width)), cappedH: Math.max(1, Math.round(height)) };
             }
             let maxW = 1920, maxH = 1080;
-            if (preset === "1080p") { maxW = 1920; maxH = 1080; }
+            if (preset === "16k") { maxW = 15360; maxH = 8640; }
+            else if (preset === "8k") { maxW = 7680; maxH = 4320; }
+            else if (preset === "4k") { maxW = 3840; maxH = 2160; }
+            else if (preset === "1440p") { maxW = 2560; maxH = 1440; }
+            else if (preset === "1080p") { maxW = 1920; maxH = 1080; }
             else if (preset === "720p") { maxW = 1280; maxH = 720; }
             else if (preset === "540p") { maxW = 960; maxH = 540; }
             else {

--- a/src/render/RendererFacade.js
+++ b/src/render/RendererFacade.js
@@ -9,7 +9,10 @@
             this.canvasRenderer = null;
             this.webglRenderer = null;
             this.activeRenderer = null;
-            this.scheduler = new globalScope.JigsawRenderScheduler();
+            const legacyMode = !!(config && config.legacyMode);
+            this.scheduler = new globalScope.JigsawRenderScheduler({
+                targetFrameMs: legacyMode ? 33 : 16
+            });
             this.sceneState = new globalScope.JigsawPuzzleSceneState();
             this.media = new globalScope.JigsawMediaSourceAdapter();
             this.hitTest = new globalScope.JigsawHitTestService();
@@ -63,12 +66,14 @@
         }
 
         selectMode(requestedMode, puzzle) {
+            const legacyMode = !!(this.config && this.config.legacyMode);
+            if (this.scheduler) this.scheduler.targetFrameMs = legacyMode ? 33 : 16;
             const normalizedMode = (requestedMode === "webgl" || requestedMode === "auto" || requestedMode === "canvas2d")
                 ? requestedMode
                 : "canvas2d";
-            this.requestedMode = normalizedMode;
-            this.mode = normalizedMode;
-            this.modeNote = "";
+            this.requestedMode = legacyMode ? "canvas2d" : normalizedMode;
+            this.mode = this.requestedMode;
+            this.modeNote = legacyMode ? "legacy mode" : "";
             if (this.activeRenderer) this.activeRenderer.setVisible(false);
             this.activeRenderer = null;
             this.activeMode = "none";
@@ -101,12 +106,12 @@
             };
 
             const webglBlockedThisSession = this.webglDowngraded === true;
-            if (webglBlockedThisSession && normalizedMode !== "canvas2d") {
-                this.modeNote = this.webglDowngradeReason || "webgl disabled for this session after downgrade";
+            if (legacyMode || (webglBlockedThisSession && normalizedMode !== "canvas2d")) {
+                if (webglBlockedThisSession) this.modeNote = this.webglDowngradeReason || "webgl disabled for this session after downgrade";
                 useCanvas();
-            } else if (normalizedMode === "webgl") {
+            } else if (this.requestedMode === "webgl") {
                 if (!tryWebGL() && this.config.autoFallback !== false) useCanvas();
-            } else if (normalizedMode === "auto") {
+            } else if (this.requestedMode === "auto") {
                 if (!tryWebGL()) useCanvas();
             } else {
                 useCanvas();

--- a/src/render/canvas2d/CanvasRenderer.js
+++ b/src/render/canvas2d/CanvasRenderer.js
@@ -136,14 +136,19 @@
             const scaleY = this.canvas.height / dh;
             this.ctx.setTransform(scaleX, 0, 0, scaleY, 0, 0);
             const pieces = this._getSortedPieces();
-            const sourceCanvas = this.puzzle.gameCanvas || null;
+            const puzzle = this.puzzle;
+            const sourceCanvas = puzzle.gameCanvas || null;
+            const videoSource = (this.mediaSource && typeof this.mediaSource.videoWidth === "number" && typeof this.mediaSource.videoHeight === "number") ? this.mediaSource : null;
+            const gifDraw = puzzle._gifDraw || null;
+            const useVideoDirect = !!(videoSource && gifDraw && gifDraw.dw > 0 && gifDraw.dh > 0);
+            const sourceW = useVideoDirect ? (this.mediaSource.videoWidth || 1) : (sourceCanvas ? sourceCanvas.width : 0);
+            const sourceH = useVideoDirect ? (this.mediaSource.videoHeight || 1) : (sourceCanvas ? sourceCanvas.height : 0);
             const heldShadowDarkness = Math.max(0, Math.min(1, parseFloat(localStorage.getItem("heldPieceShadowDarkness") || "0.35")));
             let drawn = 0;
             for (const pp of pieces) {
-                if (!pp.polypiece_canvas) continue;
-                const w = pp.polypiece_canvas.width;
-                const h = pp.polypiece_canvas.height;
-                if (w <= 0 || h <= 0) continue;
+                const w = pp.polypiece_canvas ? pp.polypiece_canvas.width : (pp.nx * puzzle.scalex);
+                const h = pp.polypiece_canvas ? pp.polypiece_canvas.height : (pp.ny * puzzle.scaley);
+                if (w <= 0 || h <= 0 || !pp.path) continue;
                 if (!this._isPieceVisible(pp, w, h)) continue;
                 const cx = pp.x + w / 2;
                 const cy = pp.y + h / 2;
@@ -155,18 +160,32 @@
                 if (pp._isHeld && !(typeof window !== "undefined" && window.rendererConfig && window.rendererConfig.legacyMode)) {
                     this._drawHeldShadow(pp, w, h, heldShadowDarkness);
                 }
-                if (sourceCanvas && pp.path && pp._mediaSample) {
+                if (pp._mediaSample) {
                     const ms = pp._mediaSample;
                     this.ctx.save();
                     this.ctx.clip(pp.path);
-                    this.ctx.drawImage(
-                        sourceCanvas,
-                        ms.sx, ms.sy, ms.w, ms.h,
-                        ms.destx, ms.desty, ms.w, ms.h
-                    );
+                    if (useVideoDirect) {
+                        const dw = gifDraw.dw;
+                        const dh = gifDraw.dh;
+                        const vx = ((ms.sx - gifDraw.dx) / dw) * sourceW;
+                        const vy = ((ms.sy - gifDraw.dy) / dh) * sourceH;
+                        const vw = (ms.w / dw) * sourceW;
+                        const vh = (ms.h / dh) * sourceH;
+                        this.ctx.drawImage(this.mediaSource, vx, vy, vw, vh, ms.destx, ms.desty, ms.w, ms.h);
+                    } else if (sourceCanvas) {
+                        this.ctx.drawImage(
+                            sourceCanvas,
+                            ms.sx, ms.sy, ms.w, ms.h,
+                            ms.destx, ms.desty, ms.w, ms.h
+                        );
+                    }
                     this.ctx.restore();
                 }
-                this.ctx.drawImage(pp.polypiece_canvas, 0, 0);
+                if (typeof pp.drawOverlayToContext === "function") {
+                    pp.drawOverlayToContext(this.ctx, w, h, puzzle);
+                } else if (pp.polypiece_canvas) {
+                    this.ctx.drawImage(pp.polypiece_canvas, 0, 0);
+                }
                 this.ctx.restore();
                 drawn++;
             }

--- a/src/render/canvas2d/CanvasRenderer.js
+++ b/src/render/canvas2d/CanvasRenderer.js
@@ -135,6 +135,12 @@
             const scaleX = this.canvas.width / dw;
             const scaleY = this.canvas.height / dh;
             this.ctx.setTransform(scaleX, 0, 0, scaleY, 0, 0);
+            this.ctx.imageSmoothingEnabled = true;
+            if (scaleX < 1 || scaleY < 1) {
+                if (typeof this.ctx.imageSmoothingQuality !== "undefined") {
+                    this.ctx.imageSmoothingQuality = "high";
+                }
+            }
             const pieces = this._getSortedPieces();
             const puzzle = this.puzzle;
             const sourceCanvas = puzzle.gameCanvas || null;

--- a/src/render/canvas2d/CanvasRenderer.js
+++ b/src/render/canvas2d/CanvasRenderer.js
@@ -58,9 +58,17 @@
             const puzzle = this.puzzle;
             if (!puzzle) return [];
             const version = puzzle._zOrderVersion || 0;
-            if (this._sortedPiecesVersion !== version || this._sortedPieces.length !== (puzzle.polyPieces || []).length) {
-                this._sortedPieces = (puzzle.polyPieces || []).slice();
-                this._sortedPieces.sort((a, b) => a.polypiece_canvas.style.zIndex - b.polypiece_canvas.style.zIndex);
+            const pieces = puzzle.polyPieces || [];
+            if (puzzle._sortedPolyPiecesByZ && puzzle._sortedPolyPiecesVersion === version && puzzle._sortedPolyPiecesByZ.length === pieces.length) {
+                return puzzle._sortedPolyPiecesByZ;
+            }
+            if (this._sortedPiecesVersion !== version || this._sortedPieces.length !== pieces.length) {
+                this._sortedPieces = pieces.slice();
+                this._sortedPieces.sort((a, b) => {
+                    const za = (a._zIndex != null) ? a._zIndex : (Number(a.polypiece_canvas && a.polypiece_canvas.style.zIndex) || 0);
+                    const zb = (b._zIndex != null) ? b._zIndex : (Number(b.polypiece_canvas && b.polypiece_canvas.style.zIndex) || 0);
+                    return za - zb;
+                });
                 this._sortedPiecesVersion = version;
             }
             return this._sortedPieces;
@@ -99,9 +107,11 @@
             };
         }
 
-        _drawHeldShadow(pp, w, h) {
+        _drawHeldShadow(pp, w, h, cachedDarkness) {
             if (!pp.path) return;
-            const darkness = Math.max(0, Math.min(1, parseFloat(localStorage.getItem("heldPieceShadowDarkness") || "0.35")));
+            const darkness = typeof cachedDarkness === "number" && !isNaN(cachedDarkness)
+                ? Math.max(0, Math.min(1, cachedDarkness))
+                : Math.max(0, Math.min(1, parseFloat(localStorage.getItem("heldPieceShadowDarkness") || "0.35")));
             const localShadow = this._worldToPieceLocal(pp, Math.max(6, w * 0.05), Math.max(6, h * 0.06));
             const blur = Math.max(18, Math.min(w, h) * 0.24);
             this.ctx.save();
@@ -127,6 +137,7 @@
             this.ctx.setTransform(scaleX, 0, 0, scaleY, 0, 0);
             const pieces = this._getSortedPieces();
             const sourceCanvas = this.puzzle.gameCanvas || null;
+            const heldShadowDarkness = Math.max(0, Math.min(1, parseFloat(localStorage.getItem("heldPieceShadowDarkness") || "0.35")));
             let drawn = 0;
             for (const pp of pieces) {
                 if (!pp.polypiece_canvas) continue;
@@ -141,7 +152,9 @@
                 const deg = (window.rotations === 180 ? 90 : window.rotations) || 0;
                 this.ctx.rotate((pp.rot || 0) * deg * Math.PI / 180);
                 this.ctx.translate(-w / 2, -h / 2);
-                if (pp._isHeld) this._drawHeldShadow(pp, w, h);
+                if (pp._isHeld && !(typeof window !== "undefined" && window.rendererConfig && window.rendererConfig.legacyMode)) {
+                    this._drawHeldShadow(pp, w, h, heldShadowDarkness);
+                }
                 if (sourceCanvas && pp.path && pp._mediaSample) {
                     const ms = pp._mediaSample;
                     this.ctx.save();

--- a/src/render/webgl/WebGLRenderer.js
+++ b/src/render/webgl/WebGLRenderer.js
@@ -42,6 +42,8 @@
             this._batchedVertexCapacity = 0;
             this._displayWidth = 0;
             this._displayHeight = 0;
+            this._cachedHeldShadowAlpha = null;
+            this._cachedHeldShadowFrameMs = -1;
         }
 
         init(puzzle) {
@@ -115,7 +117,12 @@
                 const sourceW = sourceCanvas.width || 1;
                 const sourceH = sourceCanvas.height || 1;
 
-                const heldShadowAlpha = Math.max(0, Math.min(1, parseFloat(localStorage.getItem("heldPieceShadowDarkness") || "0.35") * 0.95));
+                const legacyMode = typeof globalScope !== "undefined" && globalScope.rendererConfig && globalScope.rendererConfig.legacyMode;
+                if (this._cachedHeldShadowFrameMs !== nowMs) {
+                    this._cachedHeldShadowFrameMs = nowMs;
+                    this._cachedHeldShadowAlpha = legacyMode ? 0 : Math.max(0, Math.min(1, parseFloat(localStorage.getItem("heldPieceShadowDarkness") || "0.35") * 0.95));
+                }
+                const heldShadowAlpha = legacyMode ? 0 : this._cachedHeldShadowAlpha;
                 const activePieces = new Set();
                 const drawItems = [];
                 let numHeld = 0;
@@ -571,11 +578,15 @@
             const puzzle = this.puzzle;
             if (!puzzle) return [];
             const version = puzzle._zOrderVersion || 0;
-            if (this._sortedPiecesVersion !== version || this._sortedPieces.length !== (puzzle.polyPieces || []).length) {
-                this._sortedPieces = (puzzle.polyPieces || []).slice();
+            const pieces = puzzle.polyPieces || [];
+            if (puzzle._sortedPolyPiecesByZ && puzzle._sortedPolyPiecesVersion === version && puzzle._sortedPolyPiecesByZ.length === pieces.length) {
+                return puzzle._sortedPolyPiecesByZ;
+            }
+            if (this._sortedPiecesVersion !== version || this._sortedPieces.length !== pieces.length) {
+                this._sortedPieces = pieces.slice();
                 this._sortedPieces.sort((a, b) => {
-                    const za = Number(a.polypiece_canvas && a.polypiece_canvas.style.zIndex) || 0;
-                    const zb = Number(b.polypiece_canvas && b.polypiece_canvas.style.zIndex) || 0;
+                    const za = (a._zIndex != null) ? a._zIndex : (Number(a.polypiece_canvas && a.polypiece_canvas.style.zIndex) || 0);
+                    const zb = (b._zIndex != null) ? b._zIndex : (Number(b.polypiece_canvas && b.polypiece_canvas.style.zIndex) || 0);
                     return za - zb;
                 });
                 this._sortedPiecesVersion = version;

--- a/src/render/webgl/WebGLRenderer.js
+++ b/src/render/webgl/WebGLRenderer.js
@@ -536,7 +536,7 @@
                 if (this._uploadCountThisFrame < budget) {
                     this._bindTextureUnit(1, entry.maskTexture);
                     if (!entry.maskConfigured) {
-                        this._configureTextureDefaults(entry.maskTexture);
+                        this._configureMaskTextureDefaults(entry.maskTexture);
                         entry.maskConfigured = true;
                     }
                     gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
@@ -619,6 +619,15 @@
             gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
             gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
             gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+        }
+
+        _configureMaskTextureDefaults(texture) {
+            const gl = this.gl;
+            gl.bindTexture(gl.TEXTURE_2D, texture);
+            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
         }
 
         _bindTextureUnit(unit, texture) {

--- a/src/render/webgl/WebGLRenderer.js
+++ b/src/render/webgl/WebGLRenderer.js
@@ -44,6 +44,38 @@
             this._displayHeight = 0;
             this._cachedHeldShadowAlpha = null;
             this._cachedHeldShadowFrameMs = -1;
+            this._uploadBudgetPerFrame = 12;
+            this._uploadCountThisFrame = 0;
+            this._sharedOverlayCanvas = null;
+            this._sharedOverlayCtx = null;
+            this._sharedMaskCanvas = null;
+            this._sharedMaskCtx = null;
+        }
+
+        _ensureSharedOverlayCanvas(w, h) {
+            if (!this._sharedOverlayCanvas) {
+                this._sharedOverlayCanvas = document.createElement("canvas");
+                this._sharedOverlayCtx = this._sharedOverlayCanvas.getContext("2d");
+            }
+            const c = this._sharedOverlayCanvas;
+            if (c.width !== w || c.height !== h) {
+                c.width = Math.max(1, w | 0);
+                c.height = Math.max(1, h | 0);
+            }
+            return this._sharedOverlayCtx;
+        }
+
+        _ensureSharedMaskCanvas(w, h) {
+            if (!this._sharedMaskCanvas) {
+                this._sharedMaskCanvas = document.createElement("canvas");
+                this._sharedMaskCtx = this._sharedMaskCanvas.getContext("2d");
+            }
+            const c = this._sharedMaskCanvas;
+            if (c.width !== w || c.height !== h) {
+                c.width = Math.max(1, w | 0);
+                c.height = Math.max(1, h | 0);
+            }
+            return this._sharedMaskCtx;
         }
 
         init(puzzle) {
@@ -103,6 +135,7 @@
         renderFrame(nowMs, sceneState) {
             if (!this.enabled || !this.gl) return;
             try {
+                this._uploadCountThisFrame = 0;
                 const gl = this.gl;
                 gl.viewport(0, 0, this.canvas.width, this.canvas.height);
                 gl.clearColor(0, 0, 0, 0);
@@ -110,12 +143,18 @@
                 if (!this.puzzle || !this._mediaProgram || !this._overlayProgram || !this._shadowProgram) return;
 
                 const sourceCanvas = this.puzzle.gameCanvas || null;
-                const forceUpload = sceneState == null || !!(sceneState && sceneState.mediaContentDirty);
-                if (!sourceCanvas || !this._updateMediaTexture(sourceCanvas, forceUpload)) return;
+                const videoSource = (this.mediaSource && typeof this.mediaSource.videoWidth === "number" && typeof this.mediaSource.videoHeight === "number") ? this.mediaSource : null;
+                const gifDraw = this.puzzle._gifDraw || null;
+                const useVideoTexture = !!(videoSource && gifDraw && gifDraw.dw > 0 && gifDraw.dh > 0);
+                const mediaSource = useVideoTexture ? videoSource : sourceCanvas;
+                const forceUpload = useVideoTexture || sceneState == null || !!(sceneState && sceneState.mediaContentDirty);
+                if (!mediaSource || !this._updateMediaTexture(mediaSource, forceUpload)) return;
 
                 const pieces = this._getSortedPieces();
-                const sourceW = sourceCanvas.width || 1;
-                const sourceH = sourceCanvas.height || 1;
+                const sourceW = useVideoTexture ? (gifDraw.dw || 1) : (sourceCanvas ? sourceCanvas.width : 1);
+                const sourceH = useVideoTexture ? (gifDraw.dh || 1) : (sourceCanvas ? sourceCanvas.height : 1);
+                const sourceDx = useVideoTexture ? (gifDraw.dx || 0) : undefined;
+                const sourceDy = useVideoTexture ? (gifDraw.dy || 0) : undefined;
 
                 const legacyMode = typeof globalScope !== "undefined" && globalScope.rendererConfig && globalScope.rendererConfig.legacyMode;
                 if (this._cachedHeldShadowFrameMs !== nowMs) {
@@ -126,12 +165,11 @@
                 const activePieces = new Set();
                 const drawItems = [];
                 let numHeld = 0;
+                const puzzle = this.puzzle;
                 for (const pp of pieces) {
-                    const pieceCanvas = pp.polypiece_canvas;
-                    if (!pieceCanvas) continue;
-                    const w = pieceCanvas.width | 0;
-                    const h = pieceCanvas.height | 0;
-                    if (w <= 0 || h <= 0) continue;
+                    const w = pp.polypiece_canvas ? (pp.polypiece_canvas.width | 0) : (pp.nx * puzzle.scalex);
+                    const h = pp.polypiece_canvas ? (pp.polypiece_canvas.height | 0) : (pp.ny * puzzle.scaley);
+                    if (w <= 0 || h <= 0 || !pp.path) continue;
                     if (!pp._mediaSample) continue;
                     if (!this._isPieceVisible(pp, w, h)) continue;
                     activePieces.add(pp);
@@ -164,7 +202,7 @@
                     let pieceIdx = 0;
                     for (const item of drawItems) {
                         const pieceOffsetFloats = (numHeld + pieceIdx) * 36;
-                        this._writePieceVerticesTo(item.pp, item.w, item.h, sourceW, sourceH, this._batchedVertices, pieceOffsetFloats);
+                        this._writePieceVerticesTo(item.pp, item.w, item.h, sourceW, sourceH, this._batchedVertices, pieceOffsetFloats, sourceDx, sourceDy);
                         if (item.held) {
                             const shadowDx = Math.max(6, item.w * 0.05);
                             const shadowDy = Math.max(6, item.h * 0.06);
@@ -342,7 +380,7 @@
             return true;
         }
 
-        _updateMediaTexture(sourceCanvas, forceUpload) {
+        _updateMediaTexture(source, forceUpload) {
             const gl = this.gl;
             this._mediaUploadsThisFrame = 0;
             if (!this._mediaTexture) {
@@ -350,8 +388,9 @@
                 if (!this._mediaTexture) return false;
                 this._mediaTextureConfigured = false;
             }
-            const sw = sourceCanvas.width | 0;
-            const sh = sourceCanvas.height | 0;
+            const isVideo = source && typeof source.videoWidth === "number" && typeof source.videoHeight === "number";
+            const sw = isVideo ? (source.videoWidth | 0) : (source.width | 0);
+            const sh = isVideo ? (source.videoHeight | 0) : (source.height | 0);
             if (sw <= 0 || sh <= 0) return false;
             const dimensionsMatch = this._mediaTextureW === sw && this._mediaTextureH === sh;
             const skipUpload = forceUpload === false && dimensionsMatch && this._mediaTextureW > 0;
@@ -367,12 +406,12 @@
             gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
             try {
                 if (this._mediaTextureW !== sw || this._mediaTextureH !== sh) {
-                    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, sourceCanvas);
+                    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, source);
                     this._mediaTextureW = sw;
                     this._mediaTextureH = sh;
                     this._mediaUploadsThisFrame = 1;
                 } else {
-                    gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, sourceCanvas);
+                    gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, source);
                     this._mediaUploadsThisFrame = 1;
                 }
             } catch (e) {
@@ -399,7 +438,7 @@
             return out;
         }
 
-        _writePieceVerticesTo(pp, w, h, sourceW, sourceH, out, offsetFloats) {
+        _writePieceVerticesTo(pp, w, h, sourceW, sourceH, out, offsetFloats, sourceDx, sourceDy) {
             const cx = pp.x + w / 2;
             const cy = pp.y + h / 2;
             const deg = (globalScope.rotations === 180 ? 90 : globalScope.rotations) || 0;
@@ -409,10 +448,12 @@
             const hw = w / 2;
             const hh = h / 2;
             const ms = pp._mediaSample || { sx: 0, sy: 0, destx: 0, desty: 0, w: w, h: h };
-            const u0 = (ms.sx - ms.destx) / sourceW;
-            const u1 = (ms.sx + ms.w - ms.destx) / sourceW;
-            const v0 = (ms.sy - ms.desty) / sourceH;
-            const v1 = (ms.sy + ms.h - ms.desty) / sourceH;
+            const dx = (typeof sourceDx === "number") ? sourceDx : ms.destx;
+            const dy = (typeof sourceDy === "number") ? sourceDy : ms.desty;
+            const u0 = (ms.sx - dx) / sourceW;
+            const u1 = (ms.sx + ms.w - dx) / sourceW;
+            const v0 = (ms.sy - dy) / sourceH;
+            const v1 = (ms.sy + ms.h - dy) / sourceH;
             const tl = this._rotateAndTranslate(-hw, -hh, c, s, cx, cy);
             const tr = this._rotateAndTranslate(hw, -hh, c, s, cx, cy);
             const bl = this._rotateAndTranslate(-hw, hh, c, s, cx, cy);
@@ -467,6 +508,12 @@
 
         _ensurePieceTextures(pp) {
             const gl = this.gl;
+            const puzzle = this.puzzle;
+            if (!puzzle) return null;
+            const w = pp.polypiece_canvas ? (pp.polypiece_canvas.width | 0) : Math.max(1, pp.nx * puzzle.scalex);
+            const h = pp.polypiece_canvas ? (pp.polypiece_canvas.height | 0) : Math.max(1, pp.ny * puzzle.scaley);
+            if (w <= 0 || h <= 0 || !pp.path) return null;
+
             let entry = this._pieceTextureCache.get(pp);
             if (!entry) {
                 entry = {
@@ -483,53 +530,66 @@
             }
             if (!entry.maskTexture || !entry.overlayTexture) return null;
 
-            if (!pp._maskCanvas && pp.path && pp.polypiece_canvas) {
-                const w = pp.polypiece_canvas.width | 0;
-                const h = pp.polypiece_canvas.height | 0;
-                if (w > 0 && h > 0) {
-                    pp._maskCanvas = document.createElement("canvas");
-                    pp._maskCanvas.width = w;
-                    pp._maskCanvas.height = h;
-                    const mctx = pp._maskCanvas.getContext("2d");
-                    mctx.clearRect(0, 0, w, h);
-                    mctx.fillStyle = "#fff";
-                    mctx.fill(pp.path);
-                    pp._maskVersion = (pp._maskVersion || 0) + 1;
+            const maskVersion = pp._maskVersion != null ? pp._maskVersion : (pp._overlayVersion || 0);
+            if (entry.maskVersion !== maskVersion) {
+                const budget = this._uploadBudgetPerFrame != null ? this._uploadBudgetPerFrame : 12;
+                if (this._uploadCountThisFrame < budget) {
+                    this._bindTextureUnit(1, entry.maskTexture);
+                    if (!entry.maskConfigured) {
+                        this._configureTextureDefaults(entry.maskTexture);
+                        entry.maskConfigured = true;
+                    }
+                    gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
+                    try {
+                        if (pp._maskCanvas) {
+                            gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, pp._maskCanvas);
+                        } else {
+                            const mctx = this._ensureSharedMaskCanvas(w, h);
+                            if (mctx) {
+                                mctx.setTransform(1, 0, 0, 1, 0, 0);
+                                mctx.clearRect(0, 0, w, h);
+                                mctx.fillStyle = "#fff";
+                                mctx.fill(pp.path);
+                                gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, this._sharedMaskCanvas);
+                            }
+                        }
+                        this._uploadCountThisFrame += 1;
+                    } catch (e) {
+                        this._handleUploadFailure(e);
+                        return null;
+                    }
+                    entry.maskVersion = maskVersion;
+                    entry.maskW = w;
+                    entry.maskH = h;
                 }
             }
 
-            if (pp._maskCanvas && entry.maskVersion !== (pp._maskVersion || 0)) {
-                this._bindTextureUnit(1, entry.maskTexture);
-                if (!entry.maskConfigured) {
-                    this._configureTextureDefaults(entry.maskTexture);
-                    entry.maskConfigured = true;
+            if (entry.overlayVersion !== (pp._overlayVersion || 0)) {
+                const budget = this._uploadBudgetPerFrame != null ? this._uploadBudgetPerFrame : 12;
+                if (this._uploadCountThisFrame < budget) {
+                    this._bindTextureUnit(0, entry.overlayTexture);
+                    if (!entry.overlayConfigured) {
+                        this._configureTextureDefaults(entry.overlayTexture);
+                        entry.overlayConfigured = true;
+                    }
+                    gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
+                    try {
+                        if (pp.polypiece_canvas) {
+                            gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, pp.polypiece_canvas);
+                        } else if (typeof pp.drawOverlayToContext === "function") {
+                            const octx = this._ensureSharedOverlayCanvas(w, h);
+                            octx.setTransform(1, 0, 0, 1, 0, 0);
+                            octx.clearRect(0, 0, w, h);
+                            pp.drawOverlayToContext(octx, w, h, puzzle);
+                            gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, this._sharedOverlayCanvas);
+                        }
+                        this._uploadCountThisFrame += 1;
+                    } catch (e) {
+                        this._handleUploadFailure(e);
+                        return null;
+                    }
+                    entry.overlayVersion = pp._overlayVersion || 0;
                 }
-                gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
-                try {
-                    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, pp._maskCanvas);
-                } catch (e) {
-                    this._handleUploadFailure(e);
-                    return null;
-                }
-                entry.maskVersion = pp._maskVersion || 0;
-                entry.maskW = pp._maskCanvas.width | 0;
-                entry.maskH = pp._maskCanvas.height | 0;
-            }
-
-            if (pp.polypiece_canvas && entry.overlayVersion !== (pp._overlayVersion || 0)) {
-                this._bindTextureUnit(0, entry.overlayTexture);
-                if (!entry.overlayConfigured) {
-                    this._configureTextureDefaults(entry.overlayTexture);
-                    entry.overlayConfigured = true;
-                }
-                gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
-                try {
-                    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, pp.polypiece_canvas);
-                } catch (e) {
-                    this._handleUploadFailure(e);
-                    return null;
-                }
-                entry.overlayVersion = pp._overlayVersion || 0;
             }
             return entry;
         }

--- a/src/ui/RendererModeControl.js
+++ b/src/ui/RendererModeControl.js
@@ -138,6 +138,26 @@
                 });
             }
 
+            const videoFrameRateSelect = document.getElementById("videoFrameRateSelect");
+            if (videoFrameRateSelect) {
+                const viewState = globalScope.viewState;
+                const validValues = ["0", "16", "33", "42", "50", "66"];
+                const initialMs = (viewState && typeof viewState.videoFrameIntervalMs === "number") ? viewState.videoFrameIntervalMs : 33;
+                const initialValue = String(validValues.includes(String(initialMs)) ? initialMs : 33);
+                videoFrameRateSelect.value = initialValue;
+                const facade = deps.getRendererFacade();
+                if (facade && facade.media) facade.media.frameIntervalMs = initialMs;
+                videoFrameRateSelect.addEventListener("change", () => {
+                    const value = videoFrameRateSelect.value;
+                    if (!validValues.includes(value)) return;
+                    const ms = parseInt(value, 10);
+                    if (viewState) viewState.videoFrameIntervalMs = ms;
+                    if (globalScope.localStorage) globalScope.localStorage.setItem("videoFrameIntervalMs", String(ms));
+                    const fac = deps.getRendererFacade();
+                    if (fac && fac.media) fac.media.frameIntervalMs = ms;
+                });
+            }
+
             const legacyCheckbox = document.getElementById("rendererLegacyMode");
             if (legacyCheckbox) {
                 const saved = globalScope.localStorage && globalScope.localStorage.getItem("rendererLegacyMode");

--- a/src/ui/RendererModeControl.js
+++ b/src/ui/RendererModeControl.js
@@ -17,24 +17,31 @@
             const cfg = deps.getRendererConfig() || {};
             const modeStatus = getModeStatus();
             const webglDowngraded = modeStatus.webglDowngraded === true;
+            const legacyMode = !!cfg.legacyMode;
             const requested = cfg.mode || "auto";
             const active = modeStatus.active || "none";
-            const wantedValue = webglDowngraded ? "canvas2d" : (active === "webgl" || active === "canvas2d" ? active : requested);
+            const forceCanvas = webglDowngraded || legacyMode;
+            const wantedValue = forceCanvas ? "canvas2d" : (active === "webgl" || active === "canvas2d" ? active : requested);
             if (document.activeElement !== rendererModeControl.select && !rendererModeControl.select._rendererSelecting) {
                 rendererModeControl.select.value = wantedValue;
             }
 
             const webglOpt = rendererModeControl.select.querySelector('option[value="webgl"]');
             const autoOpt = rendererModeControl.select.querySelector('option[value="auto"]');
-            if (webglOpt) webglOpt.disabled = webglDowngraded;
-            if (autoOpt) autoOpt.disabled = false;
-            rendererModeControl.select.title = webglDowngraded
-                ? "WebGL is disabled for this session after fallback/downgrade. Use Canvas2D. Refresh to retry WebGL."
-                : "Auto: attempts WebGL and falls back to Canvas2D. WebGL: fastest GPU path when available. Canvas2D: most compatible fallback.";
+            if (webglOpt) webglOpt.disabled = forceCanvas;
+            if (autoOpt) autoOpt.disabled = forceCanvas;
+            rendererModeControl.select.title = legacyMode
+                ? "Legacy mode is on. Only Canvas2D is used; uncheck Legacy mode to enable WebGL/Auto."
+                : (webglDowngraded
+                    ? "WebGL is disabled for this session after fallback/downgrade. Use Canvas2D. Refresh to retry WebGL."
+                    : "Auto: attempts WebGL and falls back to Canvas2D. WebGL: fastest GPU path when available. Canvas2D: most compatible fallback.");
 
             if (rendererModeControl.status && rendererModeControl.fallbackRow) {
                 const note = modeStatus.note || modeStatus.webglDowngradeReason || "";
-                if (webglDowngraded) {
+                if (legacyMode) {
+                    rendererModeControl.fallbackRow.style.display = "flex";
+                    rendererModeControl.status.textContent = "Legacy mode: Canvas2D only. Uncheck Legacy mode to enable WebGL.";
+                } else if (webglDowngraded) {
                     rendererModeControl.fallbackRow.style.display = "flex";
                     rendererModeControl.status.textContent = note ? `WebGL fallback: ${note}` : "WebGL fallback active for this session.";
                 } else {
@@ -44,10 +51,12 @@
                 rendererModeControl.status.title = rendererModeControl.select.title;
             }
             if (rendererModeControl.retryBtn) {
-                rendererModeControl.retryBtn.disabled = false;
-                rendererModeControl.retryBtn.title = webglDowngraded
-                    ? "Retry WebGL now. This clears the current downgrade lock and attempts WebGL again."
-                    : "WebGL retry is only shown after a downgrade.";
+                rendererModeControl.retryBtn.disabled = legacyMode || !webglDowngraded;
+                rendererModeControl.retryBtn.title = legacyMode
+                    ? "WebGL retry is disabled in Legacy mode. Uncheck Legacy mode first."
+                    : (webglDowngraded
+                        ? "Retry WebGL now. This clears the current downgrade lock and attempts WebGL again."
+                        : "WebGL retry is only shown after a downgrade.");
             }
         }
 
@@ -55,7 +64,11 @@
             const cfg = deps.getRendererConfig() || {};
             if (mode !== "canvas2d" && mode !== "webgl" && mode !== "auto") mode = "auto";
             const modeStatus = getModeStatus();
+            const legacyMode = !!cfg.legacyMode;
             if (modeStatus.webglDowngraded === true && mode === "webgl") {
+                mode = "canvas2d";
+            }
+            if (legacyMode && mode !== "canvas2d") {
                 mode = "canvas2d";
             }
             cfg.mode = mode;
@@ -122,6 +135,34 @@
                     if (facade && puzzle && typeof puzzle.contWidth === "number" && typeof puzzle.contHeight === "number") {
                         facade.onResize(puzzle.contWidth, puzzle.contHeight);
                     }
+                });
+            }
+
+            const legacyCheckbox = document.getElementById("rendererLegacyMode");
+            if (legacyCheckbox) {
+                const saved = globalScope.localStorage && globalScope.localStorage.getItem("rendererLegacyMode");
+                const initial = saved === "true";
+                legacyCheckbox.checked = initial;
+                const cfg = deps.getRendererConfig();
+                if (cfg) cfg.legacyMode = initial;
+                legacyCheckbox.addEventListener("change", () => {
+                    const legacy = !!legacyCheckbox.checked;
+                    const c = deps.getRendererConfig();
+                    if (c) c.legacyMode = legacy;
+                    if (globalScope.localStorage) globalScope.localStorage.setItem("rendererLegacyMode", legacy ? "true" : "false");
+                    const facade = deps.getRendererFacade();
+                    const puzzle = deps.getPuzzle();
+                    if (facade) {
+                        if (facade.scheduler) facade.scheduler.targetFrameMs = legacy ? 33 : 16;
+                        if (puzzle) {
+                            facade.selectMode(legacy ? "canvas2d" : (c && c.mode) || "auto", puzzle);
+                            if (typeof facade.onResize === "function" && typeof puzzle.contWidth === "number" && typeof puzzle.contHeight === "number") {
+                                facade.onResize(puzzle.contWidth, puzzle.contHeight);
+                            }
+                            if (legacy && facade.renderDirtyPieces) facade.renderDirtyPieces();
+                        }
+                    }
+                    refreshRendererModeControl();
                 });
             }
         }

--- a/src/ui/RendererModeControl.js
+++ b/src/ui/RendererModeControl.js
@@ -111,11 +111,11 @@
             const resolutionSelect = document.getElementById("puzzleResolutionSelect");
             if (resolutionSelect && typeof deps.getPuzzleResolution === "function" && typeof deps.setPuzzleResolution === "function") {
                 const current = deps.getPuzzleResolution();
-                const resolved = (current === "1080p" || current === "720p" || current === "540p") ? current : "1080p";
+                const resolved = (current === "16k" || current === "8k" || current === "4k" || current === "1440p" || current === "1080p" || current === "720p" || current === "540p") ? current : "1080p";
                 resolutionSelect.value = resolved;
                 resolutionSelect.addEventListener("change", () => {
                     const value = resolutionSelect.value;
-                    if (value !== "1080p" && value !== "720p" && value !== "540p") return;
+                    if (value !== "16k" && value !== "8k" && value !== "4k" && value !== "1440p" && value !== "1080p" && value !== "720p" && value !== "540p") return;
                     deps.setPuzzleResolution(value);
                     const facade = deps.getRendererFacade();
                     const puzzle = deps.getPuzzle();

--- a/src/ui/ViewControls.js
+++ b/src/ui/ViewControls.js
@@ -153,6 +153,15 @@
                     if (typeof globalScope.updateGrayscaleReferenceCanvas === "function") globalScope.updateGrayscaleReferenceCanvas();
                 });
             }
+            const previewOutlineCheckbox = document.getElementById("showPreviewOutline");
+            if (previewOutlineCheckbox) {
+                previewOutlineCheckbox.checked = !!viewState.showPreviewOutline;
+                previewOutlineCheckbox.addEventListener("change", function () {
+                    viewState.showPreviewOutline = previewOutlineCheckbox.checked;
+                    try { localStorage.setItem("showPreviewOutline", String(previewOutlineCheckbox.checked)); } catch (_e) {}
+                    if (typeof globalScope.updateGrayscaleReferenceCanvas === "function") globalScope.updateGrayscaleReferenceCanvas();
+                });
+            }
             const customDropCheckbox = document.getElementById("useCustomDropLocation");
             if (customDropCheckbox) {
                 customDropCheckbox.checked = !!viewState.useCustomDropLocation;

--- a/src/ui/ViewControls.js
+++ b/src/ui/ViewControls.js
@@ -259,7 +259,10 @@
             syncLegacyViewGlobals();
             globalScope.additional_zoom = viewState.zoom;
             const puzzle = getPuzzle();
-            if (puzzle && Number.isFinite(puzzle.scalex)) puzzle.refreshConnectionDistance();
+            if (puzzle) {
+                if (puzzle._invalidateViewMetricsCache) puzzle._invalidateViewMetricsCache();
+                if (Number.isFinite(puzzle.scalex)) puzzle.refreshConnectionDistance();
+            }
         }
 
         function scheduleViewTransform() {

--- a/style.css
+++ b/style.css
@@ -466,7 +466,7 @@
       width: 320px;
       min-width: 260px;
       height: 320px;
-      min-height: 200px;
+      min-height: 120px;
       position: absolute;
       top: 50px;
       left: 50px;
@@ -578,17 +578,40 @@
       gap: 14px;
     }
     .view-controls-window-panel {
-      padding: 0 14px 14px;
+      padding: 0 10px 8px;
       display: flex;
       flex-direction: column;
       gap: 10px;
       max-height: calc(100vh - 150px);
       overflow: auto;
     }
+    .view-controls-window-panel .drawer-header {
+      align-items: center;
+      justify-content: space-between;
+      margin: 0 -10px 0;
+      padding: 4px 10px 6px;
+    }
     .cosmetic-window-panel.drawer-panel {
       gap: 10px;
       max-height: calc(100vh - 150px);
       overflow: auto;
+      padding: 0 10px 8px;
+    }
+    .cosmetic-window-panel .drawer-header {
+      align-items: center;
+      justify-content: space-between;
+      margin: 0 -10px 0;
+      padding: 4px 10px 6px;
+    }
+    #draggable3 .drawer-panel {
+      padding: 0 10px 8px;
+      gap: 10px;
+    }
+    #draggable3 .drawer-header {
+      align-items: center;
+      justify-content: space-between;
+      margin: 0 -10px 0;
+      padding: 4px 10px 6px;
     }
     .media-window-panel.drawer-panel {
       gap: 10px;
@@ -656,11 +679,9 @@
       display: flex;
       align-items: flex-start;
       flex-wrap: wrap;
-      gap: 10px;
-      padding: 10px 0 12px;
+      gap: 6px;
+      padding: 4px 14px 6px;
       margin: 0 -14px 0 -14px;
-      padding-left: 14px;
-      padding-right: 14px;
       border-bottom: 1px solid rgba(255, 255, 255, 0.08);
     }
     .drawer-header .drawer-title {
@@ -676,7 +697,7 @@
     }
     .drawer-title {
       margin: 0;
-      font-size: 1rem;
+      font-size: 0.875rem;
       font-weight: 600;
       color: #e2e8f0;
       letter-spacing: 0.02em;
@@ -912,10 +933,10 @@
     .chat-panel {
       position: absolute;
       inset: 0;
-      padding: 0 14px 14px;
+      padding: 0 10px 8px;
       display: flex;
       flex-direction: column;
-      gap: 12px;
+      gap: 6px;
       min-height: 0;
       box-sizing: border-box;
       overflow: hidden;
@@ -939,6 +960,7 @@
       }
       .view-controls-window-panel,
       .cosmetic-window-panel.drawer-panel,
+      #draggable3 .drawer-panel,
       .media-window-panel.drawer-panel {
         padding: 0 10px 10px;
       }
@@ -981,17 +1003,15 @@
       display: flex;
       align-items: center;
       justify-content: space-between;
-      gap: 10px;
-      padding: 10px 0 12px;
-      margin: 0 -14px 0;
-      padding-left: 14px;
-      padding-right: 14px;
+      gap: 6px;
+      padding: 4px 10px 6px;
+      margin: 0 -10px 0;
       border-bottom: 1px solid rgba(255, 255, 255, 0.08);
       flex-shrink: 0;
     }
     .chat-title {
       margin: 0;
-      font-size: 1rem;
+      font-size: 0.875rem;
       font-weight: 600;
       color: #e2e8f0;
       letter-spacing: 0.02em;
@@ -1002,12 +1022,12 @@
     }
     .chat-log {
       flex: 1 1 0;
-      min-height: 80px;
+      min-height: 0;
       overflow-y: auto;
       overflow-x: hidden;
-      padding: 8px 10px;
+      padding: 4px 6px;
       background: rgba(0, 0, 0, 0.25);
-      border-radius: 8px;
+      border-radius: 6px;
       border: 1px solid rgba(255, 255, 255, 0.08);
       font-size: 0.9rem;
       line-height: 1.45;
@@ -1016,7 +1036,7 @@
       text-align: left;
     }
     .chat-log > div {
-      padding: 4px 8px;
+      padding: 2px 6px;
       margin: 1px 0;
       border-radius: 4px;
     }

--- a/style.css
+++ b/style.css
@@ -551,14 +551,14 @@
       border: 1px solid rgba(255, 255, 255, 0.08);
     }
     #draggable6 {
-      display: inline-block;
+      position: absolute;
+      display: block;
       width: min(560px, 94vw);
       min-width: 340px;
-      height: fit-content;
-      min-height: 0;
+      height: 420px;
+      min-height: 200px;
       max-height: calc(100vh - 120px);
       background: #2d3748;
-      position: absolute;
       top: 140px;
       left: 140px;
       border-radius: 10px;
@@ -568,6 +568,18 @@
       z-index: 99;
       box-shadow: 0 4px 20px rgba(0, 0, 0, 0.35);
       border: 1px solid rgba(255, 255, 255, 0.08);
+    }
+    /* Load custom media panel – same pattern as Chat: panel fills draggable, header fixed, body fills remainder and scrolls */
+    #draggable6 > .media-window-panel.drawer-panel {
+      position: absolute;
+      inset: 0;
+      padding: 0 10px 8px;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      min-height: 0;
+      box-sizing: border-box;
+      overflow: hidden;
     }
 
     /* Drawer panel layout and styling */
@@ -615,15 +627,25 @@
     }
     .media-window-panel.drawer-panel {
       gap: 10px;
-      max-height: calc(100vh - 150px);
-      overflow: auto;
-      flex: 0 1 auto;
+      padding: 0 10px 8px;
+      display: flex;
+      flex-direction: column;
+    }
+    .media-window-panel .drawer-header {
+      align-items: center;
+      justify-content: space-between;
+      margin: 0 -10px 0;
+      padding: 4px 10px 6px;
+      flex-shrink: 0;
     }
     .media-window-body {
       display: flex;
       flex-direction: column;
       gap: 10px;
-      flex: 0 0 auto;
+      flex: 1 1 0;
+      min-height: 0;
+      overflow-y: auto;
+      overflow-x: hidden;
     }
     .media-window-card {
       display: flex;


### PR DESCRIPTION
## Puzzle resolution & quality
- **Resolution options:** Added 1440p, 4K, 8K, and 16K (default stays 1080p). Tooltip on the dropdown warns that resolutions above 1080p can hurt performance, especially with animations.
- **Play area:** Puzzle and pieces now use 90% of the play area (was 85%) for sharper, clearer pieces.
- **Canvas2D scaling:** When puzzle resolution is capped (e.g. 1080p) and the window is larger, Canvas2D uses higher-quality scaling so the image stays sharp.

## Legacy mode (low-performance devices)
- **New option:** Checkbox “Legacy mode (low‑performance devices)” in display options. When on: Canvas2D only, lower frame rate, no held‑piece shadow, no synced preview updates. WebGL/Auto are disabled until Legacy is turned off.
- **UI:** Short status message when Legacy is on (Canvas2D in use, how to turn off to allow WebGL again).
- **Preview:** In Legacy mode, synced preview is not updated every frame to save work.
- **Compatibility:** The older legacy renderer still uses one canvas per piece group; only the modern renderers use the new single-surface approach.

## Window headers & panel layout
- **Headers:** Chat/Log and all drawer windows (View controls, Cosmetic options, Piece drawer) use a smaller header: less padding, smaller title, same compact bar with title and minimize button.
- **Chat/Log:** Tighter spacing (log + “Type a message”); window can be resized shorter and the log area can shrink instead of a fixed minimum height.
- **Drawers:** Cosmetic options, View controls, and Piece drawer use the same layout as Chat/Log (side/bottom padding and header style).
- **Load custom media:** Header matches other panels; content scrolls under a fixed header, height fits content; open position and stacking fixed so it no longer appears in a corner or behind other UI.

## Cosmetic options
- **Video / animation framerate:** New option (Uncapped, 60, 30, 24, 20, 15 fps; default 30). Stored and reused on next load. Lowers load on slower devices.
- **Preview outline only:** New checkbox to draw an outline around the puzzle preview area (no grayscale). Outline follows the actual image/preview area (e.g. square pieces).

## Rendering & performance
- **Single loop:** Piece setup and main game run in one animation loop instead of two; less CPU use.
- **Piece movement:** Position updated with transforms instead of `left`/`top` for smoother dragging on some devices.
- **Picking:** Cached draw order and less work per pick; hit-testing uses one shared helper instead of per-piece.
- **Picked piece:** Drawn on top when grabbed (fix for appearing under others).
- **Merge check:** On drop, only nearby pieces are checked for merges.
- **Resize:** Piece redraws are spread over several frames so the window stays responsive.
- **Preview:** Synced preview only redrawn when that window is open; when closed it is not drawn every frame. Updates throttled to main puzzle timing (e.g. ~60 or 30 fps in Legacy).
- **Single surface:** Renderers (Canvas2D/WebGL) use one drawing surface for pieces instead of one per group; no separate canvas per piece group. Less work per frame and lower memory.
- **WebGL:** Piece texture updates when many pieces change are spread over several frames to reduce hitches; fixed upload budget per frame (e.g. 12), rest deferred. Piece outlines drawn with crisper edges.
- **Overlay:** Borders and hints drawn via shared `drawOverlayToContext` for both Canvas2D and WebGL (no separate overlay canvases per piece).
- **Misc:** Fewer allocations and DOM reads in the render path; cached shadow and view metrics; z-order/dirty tracking tuned to avoid full redraws on stacking changes; Fisher–Yates shuffle for piece shuffle at game start. Some debug `console.log` calls removed.

## Video, GIF & grayscale
- **Video/GIF:** Updates limited by the framerate cap (no full decode rate); puzzle and grayscale advance only when a frame is actually drawn so skipped frames don’t do extra work.
- **Canvas2D + video:** Video sampled directly per piece (no full-frame buffer).
- **WebGL + video/GIF:** Video used directly as texture source (no intermediate buffer); GIFs now update correctly in WebGL.
- **Grayscale:** With “Grayscale reference behind pieces” on, grayscale is throttled for video/GIF (~8 fps). Video + grayscale drawn from video at half resolution; GIF + grayscale throttled and drawn from current GIF frame.

## Input
- **Pan button:** Default pan is now right mouse; left-click drag is reserved for selecting pieces. Pan button (Left / Middle / Right) remains configurable in View Controls.