### PR TITLE
Fariel usability fixes

### DIFF
--- a/aplogin.js
+++ b/aplogin.js
@@ -810,6 +810,23 @@ function cleanLog() {
     }
 }
 
+function appendToChatLog(content, color) {
+    var el = typeof content === "string"
+        ? (function () {
+            var d = document.createElement("div");
+            d.innerText = content;
+            if (color) d.style.color = color;
+            return d;
+        })()
+        : content;
+    var log = document.getElementById("log");
+    if (!log) return;
+    var atBottom = log.scrollHeight - log.clientHeight <= log.scrollTop + 1;
+    log.appendChild(el);
+    cleanLog();
+    if (atBottom) log.scrollTop = log.scrollHeight - log.clientHeight;
+}
+
 var classaddcolor = [
     "rgba(6, 217, 217, 1)",
     "rgba(168, 147, 228, 1)",
@@ -930,74 +947,69 @@ function jsonListener(text, nodes) {
         messageElement.appendChild(nodeElement);
     }
 
-    var logTextarea = document.getElementById("log");
-
-    var isScrolledToBottom = logTextarea.scrollHeight - logTextarea.clientHeight <= logTextarea.scrollTop + 1;
-    logTextarea.appendChild(messageElement);
-    
-    cleanLog();
-    if (isScrolledToBottom) {
-        logTextarea.scrollTop = logTextarea.scrollHeight - logTextarea.clientHeight;
-    }
-    
+    appendToChatLog(messageElement);
 }
 window.jsonListener = jsonListener;
 
-let lastrandomnumbers = {};
-function doTrap(name, type, count = 1){
-    lastrandomnumbers[name] = Math.random() * 4;
-    console.log("my trap random number is", lastrandomnumbers[name]);
-    setTimeout(() => {
-        if (lastrandomnumbers[name] === null) {
-            return;
-        }
-        sendBounceTrapRandomNumber(name, type, count, lastrandomnumbers[name]);
-    }, lastrandomnumbers[name] * 1000);
+// Pending traps: name -> { random, fromName?, fromGame? }. random is used to compare with other player so only one trap fires when both trigger.
+var trapPending = {};
+
+function doTrap(name, type, count, sourceInfo){
+    var random = Math.random() * 4;
+    trapPending[name] = {
+        random: random,
+        fromName: sourceInfo && sourceInfo.fromName,
+        fromGame: sourceInfo && sourceInfo.fromGame
+    };
+    console.log("my trap random number is", random);
+    setTimeout(function () {
+        var p = trapPending[name];
+        if (!p) return;
+        sendBounceTrapRandomNumber(name, type, count, p.random);
+    }, random * 1000);
 }
 
 function deathListener(source, time, cause){
     console.log("Received death link from", source, "at time", time, "due to", cause);
+    var player = client && client.players ? client.players.findPlayer(source) : null;
+    var sourceInfo = {
+        fromName: player ? player.alias : (source != null ? "Slot " + source : undefined),
+        fromGame: player ? player.game : undefined
+    };
     if (receive_death_link > 0) {
-        doTrap("death"+time, "death");
+        doTrap("death" + time, "death", 1, sourceInfo);
     }
 }
 
 function sendBounceTrapRandomNumber(name, type, count, number){
     client.bounce({ "slots": [window.slot] }, [name, number]);
-    setTimeout(() => {
-        applyTrap(name, type, count);
-    }, 1000);
+    setTimeout(function () { applyTrap(name, type, count); }, 1000);
 }
 
 function applyTrap(name, type, count){
-    if(lastrandomnumbers[name] !== null){
-        if(type === "rotate"){
-            for (let i = 0; i < count; i++) {
-                window.doRotateTrap();
-            }
-        } else if(type === "swap"){
-            for (let i = 0; i < count; i++) {
-                window.doSwapTrap();
-            }
-        } else if(type === "death"){
-            for (let i = 0; i < receive_death_link; i++) {
-                window.doRotateTrap();
-                window.doSwapTrap();
-            }
-        }
-        lastrandomnumbers[name] = null;
-    }else{
+    var p = trapPending[name];
+    if (!p) {
         console.log("Trap", name, "was already applied or was not valid anymore.");
+        return;
+    }
+    var who = (p.fromName || "Someone") + (p.fromGame ? " (from " + p.fromGame + ")" : "");
+    appendToChatLog(who + " is sabotaging your experience!", "rgba(255, 100, 100, 1)");
+    delete trapPending[name];
+    if (type === "rotate") {
+        for (var i = 0; i < count; i++) window.doRotateTrap();
+    } else if (type === "swap") {
+        for (var i = 0; i < count; i++) window.doSwapTrap();
+    } else if (type === "death") {
+        for (var i = 0; i < receive_death_link; i++) {
+            window.doRotateTrap();
+            window.doSwapTrap();
+        }
     }
 }
 
 function gotRandomNumber(name, number){
     console.log("Got random number for trap", name, number);
-    if(lastrandomnumbers[name] !== null){
-        if(number < lastrandomnumbers[name]){
-            lastrandomnumbers[name] = null;
-        }
-    }
+    if (trapPending[name] && number < trapPending[name].random) delete trapPending[name];
 }
 
 const shapeParam = getUrlParameter("shape");

--- a/clientandpreview.js
+++ b/clientandpreview.js
@@ -224,7 +224,13 @@ function setMinSizeToContent(draggable, options = {}) {
         const panelW = panel ? panel.scrollWidth : 0;
         const resizerH = resizer ? resizer.offsetHeight : 0;
         if (enforceHeight) {
-            const heightPx = Math.ceil(panelH + resizerH) + 'px';
+            const minHeightPx = 200;
+            const rawH = Math.ceil(panelH + resizerH);
+            const maxHeightPx = window.innerHeight - 110;
+            const clampedH = draggable === draggable6
+                ? Math.max(minHeightPx, Math.min(rawH, maxHeightPx))
+                : rawH;
+            const heightPx = clampedH + 'px';
             draggable.style.minHeight = heightPx;
             if (setExplicitHeight) {
                 draggable.style.height = heightPx;
@@ -253,7 +259,6 @@ function restoreDiv5() {
     draggable5.style.display = (draggable5.style.display === 'none') ? 'block' : 'none';
     if (draggable5.style.display === 'block' || draggable5.style.display === '') {
         taskbarCosmeticControls.style.backgroundColor = '#909090';
-        /* Do not enforce height: cosmetic window has fixed height and scrolls; enforcing would set minHeight to full content and make the window full-screen tall */
         setMinSizeToContent(draggable5, { enforceHeight: false, enforceWidth: true });
     } else {
         taskbarCosmeticControls.style.backgroundColor = '';
@@ -304,22 +309,13 @@ document.addEventListener('keydown', (e) => {
 });
 
 
-// const resizerRight1 = document.getElementById('resizerRight1');
-// const resizerBottom1 = document.getElementById('resizerBottom1');
 const resizerCorner1 = document.getElementById('resizerCorner1');
-
-// const resizerRight2 = document.getElementById('resizerRight2');
-// const resizerBottom2 = document.getElementById('resizerBottom2');
 const resizerCorner2 = document.getElementById('resizerCorner2');
 const resizerCorner4 = document.getElementById('resizerCorner4');
 const resizerCorner5 = document.getElementById('resizerCorner5');
 const resizerCorner6 = document.getElementById('resizerCorner6');
 
-// enableResizing1(resizerRight1, true, false);
-// enableResizing1(resizerBottom1, false, true);
 enableResizing1(resizerCorner1, true, true);
-// enableResizing2(resizerRight2, true, false);
-// enableResizing2(resizerBottom2, false, true);
 enableResizing2(resizerCorner2, true, true);
 if (resizerCorner4 && draggable4) enableResizing1(resizerCorner4, true, true, draggable4);
 if (resizerCorner5 && draggable5) enableResizing1(resizerCorner5, true, true, draggable5);
@@ -366,6 +362,7 @@ function enableResizing1(resizer, horizontal, vertical, target) {
 
     document.addEventListener('touchmove', (e) => {
         if (!resizing) return;
+        e.preventDefault();
         const touch = e.touches[0];
         if (horizontal) {
             const newWidth = startWidth + (touch.clientX - startX);
@@ -379,7 +376,7 @@ function enableResizing1(resizer, horizontal, vertical, target) {
             el.style.height = `${(Math.min(newHeight, maxHeight) / window.innerHeight) * 100}vh`;
             adjustedSize(el);
         }
-    });
+    }, { passive: false });
 
     document.addEventListener('mouseup', () => { resizing = false; });
     document.addEventListener('touchend', () => { resizing = false; });
@@ -448,6 +445,7 @@ function enableResizing2(resizer, horizontal, vertical) {
 
     document.addEventListener('touchmove', (e) => {
         if (!resizing) return;
+        e.preventDefault(); 
         const touch = e.touches[0];
         if (horizontal && vertical) {
             applyResize2(touch.clientX, touch.clientY);
@@ -465,7 +463,7 @@ function enableResizing2(resizer, horizontal, vertical) {
                 adjustedSize(draggable2);
             }
         }
-    });
+    }, { passive: false });
 
     document.addEventListener('mouseup', () => { resizing = false; });
     document.addEventListener('touchend', () => { resizing = false; });

--- a/index.html
+++ b/index.html
@@ -178,7 +178,7 @@
             <li><strong>Resolution & display:</strong> Puzzle resolution now supports 1440p, 4K, 8K, and 16K (default stays 1080p). Higher resolutions can affect performance—a tooltip on the dropdown reminds you. The puzzle image uses more of the play area (90% instead of 85%) so pieces look a bit sharper. Scaling looks better when resolution is capped, and piece edges are crisper.</li>
             <li><strong>Cleaner, consistent windows:</strong> Chat/Log, View controls, Cosmetic options, Piece drawer, and Load custom media all use the same compact header and layout. Less padding, smaller titles, and the same look everywhere. Chat can be resized shorter; only the content area scrolls. Load custom media opens in the right place and stays on top of other UI.</li>
             <li><strong>Performance:</strong> Piece movement is smoother, piece picking is faster, and the piece you’re holding stays on top. Dropping a piece checks only nearby pieces for merges, so drops feel snappier. Resizing the window spreads redraws over several frames so the game stays responsive. The preview/sync window only redraws when it’s open. One animation loop instead of two and fewer things drawn each frame help on slower devices. Several console logs that could slow things down were removed.</li>
-            <li><strong>Video and animation:</strong> A new “Video / animation framerate” option (Cosmetics) lets you cap video/GIF updates at 60, 30, 24, 20, or 15 fps (default 30). Lower values reduce load on weaker devices. Video and GIF no longer push at full decode rate, so the game stays responsive. The grayscale reference behind pieces updates less often with video/GIF (about 8 times per second) to save work. Video and GIF now work correctly and more efficiently with both Canvas2D and WebGL.</li>
+            <li><strong>Video and animation:</strong> A new “Video / animation framerate” option (Cosmetics) lets you cap video/GIF updates at 30, 24, 20, or 15 fps (default 30). Lower values reduce load on weaker devices. Video and GIF no longer push at full decode rate, so the game stays responsive. The grayscale reference behind pieces updates less often with video/GIF (about 8 times per second) to save work. Video and GIF now work correctly and more efficiently with both Canvas2D and WebGL.</li>
             <li><strong>Cosmetic options:</strong> “Preview outline only” draws an outline around the puzzle preview so you can see the puzzle size without showing the full grayscale image. The outline follows the actual image area (including square pieces and other layouts).</li>
             <li><strong>View controls:</strong> The default pan button is now right mouse instead of left, so left-click drag is reserved for selecting pieces. You can still cycle the pan button (Left / Middle / Right) from the View Controls window.</li>
           </ul>
@@ -400,11 +400,9 @@
             <option value="540p">540p</option>
           </select>
         </div>
-        <div class="display-options-slider renderer-mode-slider" title="Cap how often video or animated media frames are applied. Lower framerates reduce CPU/GPU load; Uncapped uses the source&#39;s native rate.">
+        <div class="display-options-slider renderer-mode-slider" title="Cap how often video or animated media frames are applied. Lower framerates reduce CPU/GPU load.">
           <label for="videoFrameRateSelect" title="Video / animation framerate cap. Lower values improve performance on slow devices.">Video / animation framerate</label>
           <select id="videoFrameRateSelect" class="display-options-select" aria-label="Video animation framerate cap">
-            <option value="0">Uncapped</option>
-            <option value="16">60 fps</option>
             <option value="33" selected>30 fps</option>
             <option value="42">24 fps</option>
             <option value="50">20 fps</option>

--- a/script.js
+++ b/script.js
@@ -2560,6 +2560,8 @@ let lastSyncedPreviewAt = 0;
 let hasDrawnStaticSyncedPreview = false;
 let prestartPreviewDirty = true; // only redraw prestart when dirty or media animated
 let lastPrestartPreviewAt = 0; // throttle animated prestart by framerate
+const LOOP_CAP_MS = 1000 / 60; // cap loop render phase to 60 fps
+let lastLoopTickMs = 0;
 let grayscaleReferenceCanvas = null;
 let grayscaleReferenceCtx = null;
 let lastGrayscaleUpdateMs = 0;
@@ -3119,41 +3121,47 @@ document.addEventListener("gestureend", preventZoomWhileHoldingPiece, { passive:
             }
             event = null;
         }
-        // Process piece setup (e.g. merge redraws) before rendering so merged polys use updated canvas content this frame.
-        const setupStartedAt = jigsawPerfNow();
-        if (pieceSetupQueueApi && pieceSetupQueueApi.processPieceSetupQueue) pieceSetupQueueApi.processPieceSetupQueue();
-        if (perfMonitor && typeof perfMonitor.recordSetupQueue === "function") {
-            perfMonitor.recordSetupQueue(jigsawPerfNow() - setupStartedAt);
-        }
-        const renderStartedAt = jigsawPerfNow();
-        if (rendererFacade) rendererFacade.renderFrame(nowMs);
-        if (perfMonitor && typeof perfMonitor.recordRender === "function") {
-            perfMonitor.recordRender(jigsawPerfNow() - renderStartedAt);
-        }
-        if (state < 50) hasDrawnStaticSyncedPreview = false;
-        const animated = rendererFacade && typeof rendererFacade.isMediaAnimated === "function" && rendererFacade.isMediaAnimated();
-        if (animated) {
-            const previewIntervalMs = (rendererFacade && rendererFacade.scheduler) ? rendererFacade.scheduler.targetFrameMs : 16;
-            if (nowMs - lastSyncedPreviewAt >= previewIntervalMs) {
-                drawSyncedPreviewWindowFrame();
-                lastSyncedPreviewAt = nowMs;
+        // Run render phase at most 60 fps so input (move/pan) stays responsive every rAF but GPU work is capped.
+        const elapsedSinceLoopTick = nowMs - lastLoopTickMs;
+        const runRenderPhase = lastLoopTickMs === 0 || elapsedSinceLoopTick >= LOOP_CAP_MS;
+        if (runRenderPhase) {
+            lastLoopTickMs = nowMs;
+            // Process piece setup (e.g. merge redraws) before rendering so merged polys use updated canvas content this frame.
+            const setupStartedAt = jigsawPerfNow();
+            if (pieceSetupQueueApi && pieceSetupQueueApi.processPieceSetupQueue) pieceSetupQueueApi.processPieceSetupQueue();
+            if (perfMonitor && typeof perfMonitor.recordSetupQueue === "function") {
+                perfMonitor.recordSetupQueue(jigsawPerfNow() - setupStartedAt);
             }
-            hasDrawnStaticSyncedPreview = false;
-        } else if (state >= 50 && !hasDrawnStaticSyncedPreview) {
-            drawSyncedPreviewWindowFrame();
-            hasDrawnStaticSyncedPreview = true;
-        }
-        if (state === 15) {
-            const prestartAnimated = rendererFacade && typeof rendererFacade.isMediaAnimated === "function" && rendererFacade.isMediaAnimated();
-            if (prestartPreviewDirty) {
-                drawPrestartPreviewFrame();
-                prestartPreviewDirty = false;
-                lastPrestartPreviewAt = nowMs;
-            } else if (prestartAnimated) {
-                const intervalMs = (rendererFacade && rendererFacade.scheduler) ? rendererFacade.scheduler.targetFrameMs : 16;
-                if (nowMs - lastPrestartPreviewAt >= intervalMs) {
+            const renderStartedAt = jigsawPerfNow();
+            if (rendererFacade) rendererFacade.renderFrame(nowMs);
+            if (perfMonitor && typeof perfMonitor.recordRender === "function") {
+                perfMonitor.recordRender(jigsawPerfNow() - renderStartedAt);
+            }
+            if (state < 50) hasDrawnStaticSyncedPreview = false;
+            const animated = rendererFacade && typeof rendererFacade.isMediaAnimated === "function" && rendererFacade.isMediaAnimated();
+            if (animated) {
+                const previewIntervalMs = (rendererFacade && rendererFacade.scheduler) ? rendererFacade.scheduler.targetFrameMs : 16;
+                if (nowMs - lastSyncedPreviewAt >= previewIntervalMs) {
+                    drawSyncedPreviewWindowFrame();
+                    lastSyncedPreviewAt = nowMs;
+                }
+                hasDrawnStaticSyncedPreview = false;
+            } else if (state >= 50 && !hasDrawnStaticSyncedPreview) {
+                drawSyncedPreviewWindowFrame();
+                hasDrawnStaticSyncedPreview = true;
+            }
+            if (state === 15) {
+                const prestartAnimated = rendererFacade && typeof rendererFacade.isMediaAnimated === "function" && rendererFacade.isMediaAnimated();
+                if (prestartPreviewDirty) {
                     drawPrestartPreviewFrame();
+                    prestartPreviewDirty = false;
                     lastPrestartPreviewAt = nowMs;
+                } else if (prestartAnimated) {
+                    const intervalMs = (rendererFacade && rendererFacade.scheduler) ? rendererFacade.scheduler.targetFrameMs : 16;
+                    if (nowMs - lastPrestartPreviewAt >= intervalMs) {
+                        drawPrestartPreviewFrame();
+                        lastPrestartPreviewAt = nowMs;
+                    }
                 }
             }
         }

--- a/script.js
+++ b/script.js
@@ -334,7 +334,7 @@ try {
     const storedVideoFps = localStorage.getItem("videoFrameIntervalMs");
     if (storedVideoFps !== null && storedVideoFps !== "") {
         const ms = parseInt(storedVideoFps, 10);
-        if (!isNaN(ms) && ms >= 0) viewState.videoFrameIntervalMs = ms;
+        if (!isNaN(ms) && ms >= 0) viewState.videoFrameIntervalMs = (ms <= 0 || ms < 33) ? 33 : ms;
     }
 } catch (_e) {}
 try {
@@ -2558,7 +2558,9 @@ let lastSyncedPreviewAt = 0;
 let hasDrawnStaticSyncedPreview = false;
 let prestartPreviewDirty = true; // only redraw prestart when dirty or media animated
 let lastPrestartPreviewAt = 0; // throttle animated prestart by framerate
-const LOOP_CAP_MS = 1000 / 60; // cap loop render phase to 60 fps
+const TARGET_FRAME_MS_ACTIVE = 1000 / 30;
+const TARGET_FRAME_MS_STATIC = 1000 / 15;
+const TARGET_FRAME_MS_HIDDEN = 1000;
 let lastLoopTickMs = 0;
 let grayscaleReferenceCanvas = null;
 let grayscaleReferenceCtx = null;
@@ -3126,9 +3128,12 @@ document.addEventListener("gestureend", preventZoomWhileHoldingPiece, { passive:
             }
             event = null;
         }
-        // Run render phase at most 60 fps so input (move/pan) stays responsive every rAF but GPU work is capped.
+        const isPageHidden = typeof document !== "undefined" && document.visibilityState !== "visible";
+        const isStatic = !(moving && moving.pp) && !(rendererFacade && typeof rendererFacade.isMediaAnimated === "function" && rendererFacade.isMediaAnimated());
+        const currentRenderCapMs = isPageHidden ? TARGET_FRAME_MS_HIDDEN : (isStatic ? TARGET_FRAME_MS_STATIC : TARGET_FRAME_MS_ACTIVE);
+        if (rendererFacade && rendererFacade.scheduler) rendererFacade.scheduler.targetFrameMs = currentRenderCapMs;
         const elapsedSinceLoopTick = nowMs - lastLoopTickMs;
-        const runRenderPhase = lastLoopTickMs === 0 || elapsedSinceLoopTick >= LOOP_CAP_MS;
+        const runRenderPhase = lastLoopTickMs === 0 || elapsedSinceLoopTick >= currentRenderCapMs;
         if (runRenderPhase) {
             lastLoopTickMs = nowMs;
             // Process piece setup (e.g. merge redraws) before rendering so merged polys use updated canvas content this frame.
@@ -3145,7 +3150,7 @@ document.addEventListener("gestureend", preventZoomWhileHoldingPiece, { passive:
             if (state < 50) hasDrawnStaticSyncedPreview = false;
             const animated = rendererFacade && typeof rendererFacade.isMediaAnimated === "function" && rendererFacade.isMediaAnimated();
             if (animated) {
-                const previewIntervalMs = (rendererFacade && rendererFacade.scheduler) ? rendererFacade.scheduler.targetFrameMs : 16;
+                const previewIntervalMs = (rendererFacade && rendererFacade.scheduler) ? rendererFacade.scheduler.targetFrameMs : TARGET_FRAME_MS_ACTIVE;
                 if (nowMs - lastSyncedPreviewAt >= previewIntervalMs) {
                     drawSyncedPreviewWindowFrame();
                     lastSyncedPreviewAt = nowMs;
@@ -3162,7 +3167,7 @@ document.addEventListener("gestureend", preventZoomWhileHoldingPiece, { passive:
                     prestartPreviewDirty = false;
                     lastPrestartPreviewAt = nowMs;
                 } else if (prestartAnimated) {
-                    const intervalMs = (rendererFacade && rendererFacade.scheduler) ? rendererFacade.scheduler.targetFrameMs : 16;
+                    const intervalMs = (rendererFacade && rendererFacade.scheduler) ? rendererFacade.scheduler.targetFrameMs : TARGET_FRAME_MS_ACTIVE;
                     if (nowMs - lastPrestartPreviewAt >= intervalMs) {
                         drawPrestartPreviewFrame();
                         lastPrestartPreviewAt = nowMs;

--- a/script.js
+++ b/script.js
@@ -1657,8 +1657,7 @@ class Puzzle {
             event.preventDefault();
             // do not accumulate move events in events queue - keep only current one
             if (events.length && events[events.length - 1].event == "move") events.pop();
-            
-            queueGameEvent({ event: 'move', button: event.button, position: this.relativeMouseCoordinates(event) });
+            queueGameEvent({ event: 'move', button: event.button, position: { clientX: event.clientX, clientY: event.clientY } });
         });
         this.container.addEventListener("touchmove", event => {
             event.preventDefault();
@@ -1666,8 +1665,7 @@ class Puzzle {
             let ev = event.touches[0];
             // do not accumulate move events in events queue - keep only current one
             if (events.length && events[events.length - 1].event == "move") events.pop();
-            // console.log("touch", event.offsetX, event.offsetY, event)
-            queueGameEvent({ event: 'move', button: 0, position: this.relativeMouseCoordinates(ev) });
+            queueGameEvent({ event: 'move', button: 0, position: { clientX: ev.clientX, clientY: ev.clientY } });
         }, { passive: false });
 
         /* create canvas to contain picture - will be styled later */
@@ -3003,7 +3001,7 @@ document.addEventListener("gestureend", preventZoomWhileHoldingPiece, { passive:
         viewState.panY += (deltaClientY / panScaleH) * viewState.panSensitivity;
         startDragClientX = event.position.clientX;
         startDragClientY = event.position.clientY;
-        applyViewTransform();
+        applyViewTransform(true);
     }
 
     function applyPieceMoveEvent(event, perfMonitor) {
@@ -3109,6 +3107,13 @@ document.addEventListener("gestureend", preventZoomWhileHoldingPiece, { passive:
                 applyPanMoveEvent(event);
                 event = null;
             } else if (state === 55 && moving && moving.pp) {
+                if (event.position.x == null || event.position.y == null) {
+                    const pos = puzzle.screenToPuzzle(event.position.clientX, event.position.clientY);
+                    event.position.x = pos.x;
+                    event.position.y = pos.y;
+                    event.position.p_x = pos.p_x;
+                    event.position.p_y = pos.p_y;
+                }
                 applyPieceMoveEvent(event, perfMonitor);
                 event = null;
             }
@@ -4031,8 +4036,8 @@ if (window.JigsawViewControls && typeof window.JigsawViewControls.init === "func
 const forPuzzleEl = document.getElementById("forPuzzle");
 if (forPuzzleEl && typeof applyDisplayPreferences === "function") applyDisplayPreferences(forPuzzleEl);
 
-function applyViewTransform() {
-    if (_viewControlsApi && _viewControlsApi.applyViewTransform) _viewControlsApi.applyViewTransform();
+function applyViewTransform(panOnly) {
+    if (_viewControlsApi && _viewControlsApi.applyViewTransform) _viewControlsApi.applyViewTransform(panOnly);
 }
 
 function resetView() {

--- a/script.js
+++ b/script.js
@@ -4503,7 +4503,8 @@ if (window.JigsawArchipelagoBridge && typeof window.JigsawArchipelagoBridge.crea
         getPuzzle: () => puzzle,
         findPolyPieceUsingPuzzlePiece: (idx, first) => findPolyPieceUsingPuzzlePiece(idx, first),
         findPolyPieceBySyncId: (syncId) => findPolyPieceBySyncId(syncId),
-        getPolyPieceSyncId: (pp) => getPolyPieceSyncId(pp)
+        getPolyPieceSyncId: (pp) => getPolyPieceSyncId(pp),
+        markPieceDirty: (pp) => { if (rendererFacade && rendererFacade.sceneState) rendererFacade.sceneState.markPieceDirty(pp); }
     });
 }
 

--- a/script.js
+++ b/script.js
@@ -2946,6 +2946,8 @@ document.addEventListener("gestureend", preventZoomWhileHoldingPiece, { passive:
 { // scope for animate
     let stateAfterPan = 50;
     const HELD_Z_INDEX = 2147483647;
+    const DRAG_SYNC_THROTTLE_MS = 100;
+    let lastDragSyncTime = 0;
 
     function setHeldPieceState(pp, held) {
         if (!pp) return;
@@ -3022,11 +3024,15 @@ document.addEventListener("gestureend", preventZoomWhileHoldingPiece, { passive:
         moving.pp.moveAwayFromBorder();
         moving.pp.hasMovedEver = true;
         if (window.gameplayStarted && !window.play_solo) {
-            const movingSyncId = getPolyPieceSyncId(moving.pp);
-            if(window.rotations == 0){
-                if (movingSyncId !== null) change_savedata_datastorage(movingSyncId, [to_x / puzzle.contWidth, to_y / puzzle.contHeight], false);
-            }else{
-                if (movingSyncId !== null) change_savedata_datastorage(movingSyncId, [to_x / puzzle.contWidth, to_y / puzzle.contHeight, moving.pp.rot], false);
+            const now = Date.now();
+            if ((now - lastDragSyncTime) >= DRAG_SYNC_THROTTLE_MS) {
+                const movingSyncId = getPolyPieceSyncId(moving.pp);
+                if (window.rotations == 0) {
+                    if (movingSyncId !== null) change_savedata_datastorage(movingSyncId, [to_x / puzzle.contWidth, to_y / puzzle.contHeight], false);
+                } else {
+                    if (movingSyncId !== null) change_savedata_datastorage(movingSyncId, [to_x / puzzle.contWidth, to_y / puzzle.contHeight, moving.pp.rot], false);
+                }
+                lastDragSyncTime = now;
             }
         }
         if (perfMonitor && typeof perfMonitor.recordDragMove === "function") {

--- a/script.js
+++ b/script.js
@@ -2217,7 +2217,8 @@ class Puzzle {
 
         /* scale pieces: use logical size for display so resolution preset only affects quality, not on-screen size */
         // Display-only shrink factor (does not reduce gameCanvas resolution).
-        const rawAreaMultiplier = Number(window.PUZZLE_AREA_SURFACE_MULTIPLIER);
+        // Online games: 100%; local (solo) games: use PUZZLE_AREA_SURFACE_MULTIPLIER (default 75%).
+        const rawAreaMultiplier = Number(window.play_solo ? window.PUZZLE_AREA_SURFACE_MULTIPLIER : 1);
         let areaScale = 1;
         if (Number.isFinite(rawAreaMultiplier) && rawAreaMultiplier > 0) {
             // Backward-compatible behavior:

--- a/src/integration/ArchipelagoBridge.js
+++ b/src/integration/ArchipelagoBridge.js
@@ -127,6 +127,7 @@
                         pp.moveTo(x * puzzle.contWidth, y * puzzle.contHeight);
                         pp.rotateTo(r);
                         pp.hasMovedEver = true;
+                        if (deps.markPieceDirty) deps.markPieceDirty(pp);
                     }
                 }
             } else {

--- a/src/media/MediaBindings.js
+++ b/src/media/MediaBindings.js
@@ -33,6 +33,18 @@
             return deps.getPuzzle ? deps.getPuzzle() : null;
         }
 
+        function tryRestoreWebGLIfSourceSafe() {
+            const puzzle = getPuzzle();
+            const facade = getRendererFacade();
+            if (!puzzle || !facade || !facade.webglDowngraded) return;
+            if (puzzle._webglStartBlockedReason) return;
+            const cfg = deps.getRendererConfig && deps.getRendererConfig();
+            const preferredMode = (cfg && cfg.mode) || "auto";
+            if (typeof facade.retryWebGLAfterDowngrade === "function") {
+                facade.retryWebGLAfterDowngrade(preferredMode);
+            }
+        }
+
         function isGifSource(src) {
             return typeof src === "string" && (
                 src.startsWith("data:image/gif") || /\.gif(\?|#|$)/i.test(src)
@@ -304,6 +316,7 @@
             const cfg = deps.getRendererConfig();
             if (cfg) cfg.media = options.kind || "video";
             if (rendererFacade) rendererFacade.setVideoSource(video, options.kind || "video");
+            tryRestoreWebGLIfSourceSafe();
         }
 
         function setImagePath(path, options = {}) {
@@ -397,6 +410,7 @@
             // Startup/state machine will react to srcImage load event.
             if (puzzle.srcImage.complete && (puzzle.srcImage.naturalWidth | 0) > 0 && (puzzle.srcImage.naturalHeight | 0) > 0) {
                 deps.loadImageFunction();
+                tryRestoreWebGLIfSourceSafe();
             }
         }
 
@@ -452,6 +466,7 @@
             const cfg = deps.getRendererConfig();
             if (cfg) cfg.media = "camera";
             rendererFacade.setVideoSource(cameraVideo, "camera");
+            tryRestoreWebGLIfSourceSafe();
         }
 
         async function startLinkCaptureSource(stream) {
@@ -468,6 +483,7 @@
             const cfg = deps.getRendererConfig();
             if (cfg) cfg.media = "display";
             rendererFacade.setVideoSource(displayVideo, "display");
+            tryRestoreWebGLIfSourceSafe();
         }
 
         function loadInitialFile() {

--- a/src/render/RenderScheduler.js
+++ b/src/render/RenderScheduler.js
@@ -2,7 +2,7 @@
 
 (function initRenderScheduler(globalScope) {
     class RenderScheduler {
-        constructor({ targetFrameMs = 16, maxRenderMs = 8 } = {}) {
+        constructor({ targetFrameMs = 1000 / 30, maxRenderMs = 8 } = {}) {
             this.targetFrameMs = targetFrameMs;
             this.maxRenderMs = maxRenderMs;
             this.lastFrameAt = 0;

--- a/src/render/RendererFacade.js
+++ b/src/render/RendererFacade.js
@@ -345,7 +345,7 @@
         isMediaAnimated() {
             const status = this.media && this.media.getStatus ? this.media.getStatus() : null;
             const kind = status && status.kind ? status.kind : "image";
-            return kind === "video" || kind === "camera" || kind === "display" || kind === "gif-decoded";
+            return kind === "video" || kind === "camera" || kind === "display" || kind === "gif-decoded" || kind === "gif";
         }
 
         renderFrame(nowMs) {

--- a/src/render/RendererFacade.js
+++ b/src/render/RendererFacade.js
@@ -372,19 +372,6 @@
             }
             if (!shouldRenderThisFrame) return;
 
-            if (this.media && puzzle && !mediaAdvanced) {
-                const status = this.media.getStatus ? this.media.getStatus() : null;
-                const kind = status && status.kind ? status.kind : "image";
-                const animated = kind === "video" || kind === "camera" || kind === "display" || kind === "gif-decoded";
-                if (animated) {
-                    const frameSource = this.media.getFrameSource();
-                    if (frameSource && puzzle.applyMediaFrame && puzzle.applyMediaFrame(frameSource, nowMs)) {
-                        this.sceneState.markAllDirty();
-                        mediaAdvanced = true;
-                    }
-                }
-            }
-
             // Catch WebGL failures before dirty-skip can short-circuit fallback.
             if (this._isWebGLRuntimeFailed()) {
                 this._fallbackToCanvasFromWebGL("runtime-precheck");

--- a/src/render/RendererFacade.js
+++ b/src/render/RendererFacade.js
@@ -27,7 +27,7 @@
             this.webglRenderer = null;
             this.activeRenderer = null;
             this.scheduler = new globalScope.JigsawRenderScheduler({
-                targetFrameMs: 16
+                targetFrameMs: 1000 / 30
             });
             this.sceneState = new globalScope.JigsawPuzzleSceneState();
             this.media = new globalScope.JigsawMediaSourceAdapter();
@@ -82,7 +82,7 @@
         }
 
         selectMode(requestedMode, puzzle) {
-            if (this.scheduler) this.scheduler.targetFrameMs = 16;
+            if (this.scheduler) this.scheduler.targetFrameMs = 1000 / 30;
             const normalizedMode = (requestedMode === "webgl" || requestedMode === "auto" || requestedMode === "canvas2d")
                 ? requestedMode
                 : "canvas2d";

--- a/src/render/canvas2d/CanvasRenderer.js
+++ b/src/render/canvas2d/CanvasRenderer.js
@@ -27,8 +27,38 @@
             this._staticCtx = null;
             this._staticLayerDirty = true;
             this._lastStaticDrawCount = 0;
+            this._heldOverlayCanvas = null;
+            this._heldOverlayCtx = null;
+            this._heldPiecesCountLastFrame = -1;
             this._cachedHeldShadowDarkness = null;
             this._cachedHeldShadowAt = 0;
+        }
+
+        _ensureHeldOverlay() {
+            if (!this.canvas || !this.container) return;
+            const w = this.canvas.width;
+            const h = this.canvas.height;
+            if (!this._heldOverlayCanvas) {
+                this._heldOverlayCanvas = document.createElement("canvas");
+                this._heldOverlayCanvas.className = "jigsaw-held-overlay-renderer";
+                this._heldOverlayCanvas.style.position = "absolute";
+                this._heldOverlayCanvas.style.left = "0px";
+                this._heldOverlayCanvas.style.top = "0px";
+                this._heldOverlayCanvas.style.width = "100%";
+                this._heldOverlayCanvas.style.height = "100%";
+                this._heldOverlayCanvas.style.zIndex = "100000000";
+                this._heldOverlayCanvas.style.pointerEvents = "none";
+                this._heldOverlayCtx = this._heldOverlayCanvas.getContext("2d");
+                if (this.canvas.nextSibling) {
+                    this.container.insertBefore(this._heldOverlayCanvas, this.canvas.nextSibling);
+                } else {
+                    this.container.appendChild(this._heldOverlayCanvas);
+                }
+            }
+            if (this._heldOverlayCanvas.width !== w || this._heldOverlayCanvas.height !== h) {
+                this._heldOverlayCanvas.width = w;
+                this._heldOverlayCanvas.height = h;
+            }
         }
 
         _isOverlayOversampleEnabled() {
@@ -61,10 +91,12 @@
             this.canvas.style.height = "100%";
             this.enabled = true;
             this._markStaticLayerDirty();
+            this._ensureHeldOverlay();
         }
 
         setVisible(visible) {
             this.canvas.style.display = visible ? "block" : "none";
+            if (this._heldOverlayCanvas) this._heldOverlayCanvas.style.display = visible ? "block" : "none";
         }
 
         setMediaSource(source) {
@@ -78,12 +110,16 @@
             this.canvas.height = Math.max(1, Math.round(bufferH));
             this._displayWidth = (displayW != null && displayH != null) ? Math.max(1, Math.round(displayW)) : this.canvas.width;
             this._displayHeight = (displayW != null && displayH != null) ? Math.max(1, Math.round(displayH)) : this.canvas.height;
+            this._ensureHeldOverlay();
             this._markStaticLayerDirty();
         }
 
         clear() {
             if (!this.enabled) return;
             this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+            if (this._heldOverlayCtx && this._heldOverlayCanvas) {
+                this._heldOverlayCtx.clearRect(0, 0, this._heldOverlayCanvas.width, this._heldOverlayCanvas.height);
+            }
         }
 
         _getSortedPieces() {
@@ -251,11 +287,16 @@
             return true;
         }
 
-        _shouldRebuildStaticLayer(sceneState) {
+        // Rebuild static layer only when something on it actually changed. Do not rebuild when the
+        // only dirty pieces are held (they are drawn on the overlay); do rebuild when any
+        // non-held piece is dirty (e.g. position/rotation from network or merge).
+        // Also rebuild when held count changes (pick up or drop) so static no longer includes the held piece.
+        _shouldRebuildStaticLayer(sceneState, heldCount) {
             if (this._staticLayerDirty) return true;
             if (!sceneState) return true;
             if (sceneState.mediaContentDirty) return true;
             if (sceneState.zOrderDirty) return true;
+            if (typeof heldCount === "number" && heldCount !== this._heldPiecesCountLastFrame) return true;
             if (sceneState.dirtyPieces && sceneState.dirtyPieces.size > 0) {
                 for (const dirtyPiece of sceneState.dirtyPieces) {
                     if (!dirtyPiece || !dirtyPiece._isHeld) return true;
@@ -301,7 +342,8 @@
             }
 
             this._ensureStaticLayer();
-            if (this._shouldRebuildStaticLayer(sceneState)) {
+            const rebuiltStatic = this._shouldRebuildStaticLayer(sceneState, this._heldPieces.length);
+            if (rebuiltStatic) {
                 const sctx = this._staticCtx;
                 sctx.setTransform(1, 0, 0, 1, 0, 0);
                 sctx.clearRect(0, 0, this._staticCanvas.width, this._staticCanvas.height);
@@ -314,20 +356,35 @@
                 }
                 this._lastStaticDrawCount = staticDrawn;
                 this._staticLayerDirty = false;
+                this.ctx.setTransform(1, 0, 0, 1, 0, 0);
+                this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+                if (this._staticCanvas) this.ctx.drawImage(this._staticCanvas, 0, 0);
             }
 
-            this.ctx.setTransform(1, 0, 0, 1, 0, 0);
-            this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
-            if (this._staticCanvas) this.ctx.drawImage(this._staticCanvas, 0, 0);
-            this._configureDrawContext(this.ctx);
+            this._ensureHeldOverlay();
+            const heldCtx = this._heldOverlayCtx;
+            const heldCanvas = this._heldOverlayCanvas;
+            if (heldCtx && heldCanvas) {
+                heldCtx.setTransform(1, 0, 0, 1, 0, 0);
+                heldCtx.clearRect(0, 0, heldCanvas.width, heldCanvas.height);
+                this._configureDrawContext(heldCtx);
+            }
             let heldDrawn = 0;
+            const drawHeldTo = heldCtx || this.ctx;
+            if (!heldCtx && rebuiltStatic === false) {
+                this.ctx.setTransform(1, 0, 0, 1, 0, 0);
+                this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+                if (this._staticCanvas) this.ctx.drawImage(this._staticCanvas, 0, 0);
+                this._configureDrawContext(this.ctx);
+            }
             for (const pp of this._heldPieces) {
-                if (this._drawPieceToContext(this.ctx, pp, puzzle, sourceCanvas, scaleSrcX, scaleSrcY, heldShadowDarkness, true)) {
+                if (this._drawPieceToContext(drawHeldTo, pp, puzzle, sourceCanvas, scaleSrcX, scaleSrcY, heldShadowDarkness, true)) {
                     heldDrawn++;
                 }
             }
             this.lastDrawCount = this._lastStaticDrawCount + heldDrawn;
             this.lastMediaUploads = 0;
+            this._heldPiecesCountLastFrame = this._heldPieces.length;
         }
 
         renderDirtyPieces(sceneState) {
@@ -338,6 +395,11 @@
 
         destroy() {
             this.enabled = false;
+            if (this._heldOverlayCanvas && this._heldOverlayCanvas.parentElement) {
+                this._heldOverlayCanvas.parentElement.removeChild(this._heldOverlayCanvas);
+            }
+            this._heldOverlayCanvas = null;
+            this._heldOverlayCtx = null;
             if (this.canvas.parentElement) this.canvas.parentElement.removeChild(this.canvas);
             this._staticCanvas = null;
             this._staticCtx = null;

--- a/src/render/canvas2d/CanvasRenderer.js
+++ b/src/render/canvas2d/CanvasRenderer.js
@@ -153,15 +153,10 @@
                 darkness = this._cachedHeldShadowDarkness;
             }
             const localShadow = this._worldToPieceLocal(pp, Math.max(6, w * 0.05), Math.max(6, h * 0.06));
-            const blur = Math.max(18, Math.min(w, h) * 0.24);
             ctx.save();
             ctx.translate(localShadow.x, localShadow.y);
-            ctx.shadowColor = `rgba(0,0,0,${Math.min(1, darkness * 0.85)})`;
-            ctx.shadowBlur = blur;
-            ctx.shadowOffsetX = 0;
-            ctx.shadowOffsetY = 0;
-            // Keep the core very faint so most weight comes from the blurred edge.
-            ctx.fillStyle = `rgba(0,0,0,${Math.min(1, darkness * 0.12)})`;
+            // Solid offset shadow only; no shadowBlur to avoid GPU cost.
+            ctx.fillStyle = `rgba(0,0,0,${Math.min(1, darkness * 0.35)})`;
             ctx.fill(pp.path);
             ctx.restore();
         }

--- a/src/render/canvas2d/CanvasRenderer.js
+++ b/src/render/canvas2d/CanvasRenderer.js
@@ -142,8 +142,7 @@
             return this._sortedPieces;
         }
 
-        _isPieceVisible(pp, w, h) {
-            const deg = (window.rotations === 180 ? 90 : window.rotations) || 0;
+        _isPieceVisible(pp, w, h, deg, dw, dh) {
             const angle = (pp.rot || 0) * deg * Math.PI / 180;
             let hw = w / 2;
             let hh = h / 2;
@@ -158,8 +157,6 @@
             const cx = pp.x + w / 2;
             const cy = pp.y + h / 2;
             if (cx + hw < 0 || cy + hh < 0) return false;
-            const dw = this._displayWidth || this.canvas.width;
-            const dh = this._displayHeight || this.canvas.height;
             if (cx - hw > dw || cy - hh > dh) return false;
             return true;
         }
@@ -228,11 +225,11 @@
             }
         }
 
-        _drawPieceToContext(ctx, pp, puzzle, sourceCanvas, scaleSrcX, scaleSrcY, heldShadowDarkness, drawHeldShadow) {
+        _drawPieceToContext(ctx, pp, puzzle, sourceCanvas, scaleSrcX, scaleSrcY, heldShadowDarkness, drawHeldShadow, viewportDeg, viewportDw, viewportDh) {
             const w = pp.nx * puzzle.scalex;
             const h = pp.ny * puzzle.scaley;
             if (w <= 0 || h <= 0 || !pp.path) return false;
-            if (!this._isPieceVisible(pp, w, h)) return false;
+            if (!this._isPieceVisible(pp, w, h, viewportDeg, viewportDw, viewportDh)) return false;
             const cx = pp.x + w / 2;
             const cy = pp.y + h / 2;
             ctx.save();
@@ -331,6 +328,9 @@
                 this._cachedHeldShadowAt = now;
             }
             const heldShadowDarkness = this._cachedHeldShadowDarkness;
+            const viewportDeg = (window.rotations === 180 ? 90 : window.rotations) || 0;
+            const viewportDw = this._displayWidth || this.canvas.width;
+            const viewportDh = this._displayHeight || this.canvas.height;
 
             if (!this._heldPieces) this._heldPieces = [];
             if (!this._staticPieces) this._staticPieces = [];
@@ -350,7 +350,7 @@
                 this._configureDrawContext(sctx);
                 let staticDrawn = 0;
                 for (const pp of this._staticPieces) {
-                    if (this._drawPieceToContext(sctx, pp, puzzle, sourceCanvas, scaleSrcX, scaleSrcY, heldShadowDarkness, false)) {
+                    if (this._drawPieceToContext(sctx, pp, puzzle, sourceCanvas, scaleSrcX, scaleSrcY, heldShadowDarkness, false, viewportDeg, viewportDw, viewportDh)) {
                         staticDrawn++;
                     }
                 }
@@ -378,7 +378,7 @@
                 this._configureDrawContext(this.ctx);
             }
             for (const pp of this._heldPieces) {
-                if (this._drawPieceToContext(drawHeldTo, pp, puzzle, sourceCanvas, scaleSrcX, scaleSrcY, heldShadowDarkness, true)) {
+                if (this._drawPieceToContext(drawHeldTo, pp, puzzle, sourceCanvas, scaleSrcX, scaleSrcY, heldShadowDarkness, true, viewportDeg, viewportDw, viewportDh)) {
                     heldDrawn++;
                 }
             }

--- a/src/render/canvas2d/CanvasRenderer.js
+++ b/src/render/canvas2d/CanvasRenderer.js
@@ -36,8 +36,29 @@
 
         _ensureHeldOverlay() {
             if (!this.canvas || !this.container) return;
-            const w = this.canvas.width;
-            const h = this.canvas.height;
+            const cw = this.canvas.width;
+            const ch = this.canvas.height;
+            let tw = this.container.clientWidth || 0;
+            let th = this.container.clientHeight || 0;
+            if (tw === 0 && th === 0 && this.puzzle) {
+                tw = this.puzzle.contWidth || 0;
+                th = this.puzzle.contHeight || 0;
+            }
+            let w;
+            let h;
+            if (cw <= 0 || ch <= 0) {
+                w = tw;
+                h = th;
+            } else if (cw === 1 && ch === 1 && (tw > 1 || th > 1)) {
+                w = tw;
+                h = th;
+            } else {
+                w = cw;
+                h = ch;
+            }
+            w = Math.max(1, Math.round(w));
+            h = Math.max(1, Math.round(h));
+
             if (!this._heldOverlayCanvas) {
                 this._heldOverlayCanvas = document.createElement("canvas");
                 this._heldOverlayCanvas.className = "jigsaw-held-overlay-renderer";
@@ -49,6 +70,12 @@
                 this._heldOverlayCanvas.style.zIndex = "100000000";
                 this._heldOverlayCanvas.style.pointerEvents = "none";
                 this._heldOverlayCtx = this._heldOverlayCanvas.getContext("2d");
+                if (this.canvas.nextSibling) {
+                    this.container.insertBefore(this._heldOverlayCanvas, this.canvas.nextSibling);
+                } else {
+                    this.container.appendChild(this._heldOverlayCanvas);
+                }
+            } else if (!this._heldOverlayCanvas.parentElement) {
                 if (this.canvas.nextSibling) {
                     this.container.insertBefore(this._heldOverlayCanvas, this.canvas.nextSibling);
                 } else {

--- a/src/render/webgl/WebGLRenderer.js
+++ b/src/render/webgl/WebGLRenderer.js
@@ -197,12 +197,15 @@
                 const drawItems = [];
                 let numHeld = 0;
                 const puzzle = this.puzzle;
+                const deg = (globalScope.rotations === 180 ? 90 : globalScope.rotations) || 0;
+                const dw = this._displayWidth || this.canvas.width;
+                const dh = this._displayHeight || this.canvas.height;
                 for (const pp of pieces) {
                     const w = pp.nx * puzzle.scalex;
                     const h = pp.ny * puzzle.scaley;
                     if (w <= 0 || h <= 0 || !pp.path) continue;
                     if (!pp._mediaSample) continue;
-                    if (!this._isPieceVisible(pp, w, h)) continue;
+                    if (!this._isPieceVisible(pp, w, h, deg, dw, dh)) continue;
 
                     const cache = this._ensurePieceTextures(pp, sceneState);
                     if (!cache || !cache.maskTexture || !cache.overlayTexture) continue;
@@ -707,8 +710,7 @@
             return this._sortedPieces;
         }
 
-        _isPieceVisible(pp, w, h) {
-            const deg = (globalScope.rotations === 180 ? 90 : globalScope.rotations) || 0;
+        _isPieceVisible(pp, w, h, deg, dw, dh) {
             const angle = (pp.rot || 0) * deg * Math.PI / 180;
             let hw = w / 2;
             let hh = h / 2;
@@ -723,8 +725,6 @@
             const cx = pp.x + w / 2;
             const cy = pp.y + h / 2;
             if (cx + hw < 0 || cy + hh < 0) return false;
-            const dw = this._displayWidth || this.canvas.width;
-            const dh = this._displayHeight || this.canvas.height;
             if (cx - hw > dw || cy - hh > dh) return false;
             return true;
         }

--- a/src/render/webgl/WebGLRenderer.js
+++ b/src/render/webgl/WebGLRenderer.js
@@ -49,6 +49,74 @@
             this._sharedOverlayCtx = null;
             this._sharedMaskCanvas = null;
             this._sharedMaskCtx = null;
+            this._atlasTextures = [];
+            this._atlasManager = null;
+        }
+
+        _createAtlasManager(gl) {
+            const maxSize = gl.getParameter(gl.MAX_TEXTURE_SIZE) || 4096;
+            const atlasWidth = maxSize;
+            const atlasHeight = maxSize;
+            const textures = this._atlasTextures;
+            const freeRectsByAtlas = [];
+
+            const createAtlasTexture = () => {
+                const tex = gl.createTexture();
+                if (!tex) return null;
+                gl.bindTexture(gl.TEXTURE_2D, tex);
+                gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, atlasWidth, atlasHeight, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+                gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+                gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+                gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+                gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+                const idx = textures.length;
+                textures.push(tex);
+                freeRectsByAtlas.push([{ x: 0, y: 0, w: atlasWidth, h: atlasHeight }]);
+                return idx;
+            };
+
+            return {
+                atlasWidth,
+                atlasHeight,
+                allocate(w, h) {
+                    return this._allocateInAtlas(w, h, -1);
+                },
+                allocateFromAtlas(preferredAtlasIndex, w, h) {
+                    return this._allocateInAtlas(w, h, preferredAtlasIndex);
+                },
+                _allocateInAtlas(w, h, preferredAtlasIndex) {
+                    const wu = Math.ceil(Math.max(1, w));
+                    const hu = Math.ceil(Math.max(1, h));
+                    const order = preferredAtlasIndex >= 0
+                        ? [preferredAtlasIndex].concat(freeRectsByAtlas.map((_, i) => i).filter(i => i !== preferredAtlasIndex))
+                        : freeRectsByAtlas.map((_, i) => i);
+                    for (let ai of order) {
+                        if (ai >= freeRectsByAtlas.length) continue;
+                        const freeRects = freeRectsByAtlas[ai];
+                        for (let i = 0; i < freeRects.length; i++) {
+                            const r = freeRects[i];
+                            if (r.w >= wu && r.h >= hu) {
+                                freeRects.splice(i, 1);
+                                if (r.w > wu) freeRects.push({ x: r.x + wu, y: r.y, w: r.w - wu, h: r.h });
+                                if (r.h > hu) freeRects.push({ x: r.x, y: r.y + hu, w: wu, h: r.h - hu });
+                                return { atlasIndex: ai, x: r.x, y: r.y, w: wu, h: hu };
+                            }
+                        }
+                    }
+                    if (preferredAtlasIndex >= 0) return null;
+                    const idx = createAtlasTexture();
+                    if (idx === null) return null;
+                    return this.allocate(w, h);
+                },
+                release(atlasIndex, x, y, w, h) {
+                    if (atlasIndex >= 0 && atlasIndex < freeRectsByAtlas.length) {
+                        freeRectsByAtlas[atlasIndex].push({ x, y, w, h });
+                    }
+                },
+                reset() {
+                    freeRectsByAtlas.length = 0;
+                }
+            };
         }
 
         _isOverlayOversampleEnabled() {
@@ -205,18 +273,34 @@
                     if (!this._isPieceVisible(pp, w, h, deg, dw, dh)) continue;
 
                     const cache = this._ensurePieceTextures(pp, sceneState);
-                    if (!cache || !cache.maskTexture || !cache.overlayTexture) continue;
+                    if (!cache || cache.atlasIndex == null || cache.overlayAtlasIndex == null) continue;
                     cache.lastSeenFrame = visibleFrameMark;
                     const held = !!pp._isHeld;
                     if (held) numHeld++;
+                    const atlasW = this._atlasManager.atlasWidth;
+                    const atlasH = this._atlasManager.atlasHeight;
                     drawItems.push({
                         pp,
                         w,
                         h,
-                        maskTexture: cache.maskTexture,
-                        overlayTexture: cache.overlayTexture,
-                        maskW: cache.maskW || w,
-                        maskH: cache.maskH || h,
+                        maskAtlasTexture: this._atlasTextures[cache.atlasIndex],
+                        overlayAtlasTexture: this._atlasTextures[cache.overlayAtlasIndex],
+                        atlasIndex: cache.atlasIndex,
+                        overlayAtlasIndex: cache.overlayAtlasIndex,
+                        maskAtlasRect: [
+                            cache.maskX / atlasW,
+                            cache.maskY / atlasH,
+                            (cache.maskX + cache.maskW) / atlasW,
+                            (cache.maskY + cache.maskH) / atlasH
+                        ],
+                        overlayAtlasRect: [
+                            cache.overlayX / atlasW,
+                            cache.overlayY / atlasH,
+                            (cache.overlayX + cache.overlayW) / atlasW,
+                            (cache.overlayY + cache.overlayH) / atlasH
+                        ],
+                        maskW: cache.maskW_texel || w,
+                        maskH: cache.maskH_texel || h,
                         held,
                         heldShadowAlpha
                     });
@@ -263,13 +347,14 @@
                         if (item.held && item.shadowVertexOffsetFloats >= 0) {
                             this._setVertexOffset(item.shadowVertexOffsetFloats * 4);
                             gl.uniform1f(this._pieceProgram.uMode, 0.0);
-                            this._bindTextureUnit(0, item.maskTexture);
-                            gl.uniform1i(this._pieceProgram.uMask, 0);
+                            this._bindTextureUnit(0, item.maskAtlasTexture);
+                            gl.uniform1i(this._pieceProgram.uAtlas, 0);
+                            gl.uniform4f(this._pieceProgram.uMaskAtlasRect, item.maskAtlasRect[0], item.maskAtlasRect[1], item.maskAtlasRect[2], item.maskAtlasRect[3]);
                             gl.uniform1f(this._pieceProgram.uAlpha, item.heldShadowAlpha);
                             gl.uniform2f(
                                 this._pieceProgram.uTexel,
-                                1 / Math.max(1, item.maskW),
-                                1 / Math.max(1, item.maskH)
+                                (item.maskAtlasRect[2] - item.maskAtlasRect[0]) / Math.max(1, item.maskW),
+                                (item.maskAtlasRect[3] - item.maskAtlasRect[1]) / Math.max(1, item.maskH)
                             );
                             gl.uniform1f(this._pieceProgram.uSoftness, 3.0);
                             gl.drawArrays(gl.TRIANGLES, 0, 6);
@@ -278,15 +363,17 @@
                         this._setVertexOffset(item.pieceVertexOffsetFloats * 4);
                         gl.uniform1f(this._pieceProgram.uMode, 1.0);
                         this._bindTextureUnit(0, this._mediaTexture);
+                        this._bindTextureUnit(1, item.maskAtlasTexture);
                         gl.uniform1i(this._pieceProgram.uMedia, 0);
-                        this._bindTextureUnit(1, item.maskTexture);
-                        gl.uniform1i(this._pieceProgram.uMask, 1);
+                        gl.uniform1i(this._pieceProgram.uAtlas, 1);
+                        gl.uniform4f(this._pieceProgram.uMaskAtlasRect, item.maskAtlasRect[0], item.maskAtlasRect[1], item.maskAtlasRect[2], item.maskAtlasRect[3]);
                         gl.drawArrays(gl.TRIANGLES, 0, 6);
 
                         this._setVertexOffset(item.pieceVertexOffsetFloats * 4);
                         gl.uniform1f(this._pieceProgram.uMode, 2.0);
-                        this._bindTextureUnit(0, item.overlayTexture);
-                        gl.uniform1i(this._pieceProgram.uOverlay, 0);
+                        this._bindTextureUnit(0, item.overlayAtlasTexture);
+                        gl.uniform1i(this._pieceProgram.uAtlas, 0);
+                        gl.uniform4f(this._pieceProgram.uOverlayAtlasRect, item.overlayAtlasRect[0], item.overlayAtlasRect[1], item.overlayAtlasRect[2], item.overlayAtlasRect[3]);
                         gl.drawArrays(gl.TRIANGLES, 0, 6);
                     }
                 }
@@ -309,11 +396,10 @@
             this.enabled = false;
             this.supportsPieceRendering = false;
             if (this.gl) {
-                for (const entry of this._pieceTextureCache.values()) {
-                    if (entry.maskTexture) this.gl.deleteTexture(entry.maskTexture);
-                    if (entry.overlayTexture) this.gl.deleteTexture(entry.overlayTexture);
-                }
                 this._pieceTextureCache.clear();
+                for (const tex of this._atlasTextures) this.gl.deleteTexture(tex);
+                this._atlasTextures = [];
+                this._atlasManager = null;
                 if (this._vertexBuffer) this.gl.deleteBuffer(this._vertexBuffer);
                 if (this._mediaTexture) this.gl.deleteTexture(this._mediaTexture);
                 if (this._pieceProgram && this._pieceProgram.program) this.gl.deleteProgram(this._pieceProgram.program);
@@ -333,10 +419,9 @@
             if (this._vertexBuffer) gl.deleteBuffer(this._vertexBuffer);
             if (this._mediaTexture) gl.deleteTexture(this._mediaTexture);
             if (this._pieceProgram && this._pieceProgram.program) gl.deleteProgram(this._pieceProgram.program);
-            for (const entry of this._pieceTextureCache.values()) {
-                if (entry.maskTexture) gl.deleteTexture(entry.maskTexture);
-                if (entry.overlayTexture) gl.deleteTexture(entry.overlayTexture);
-            }
+            for (const tex of this._atlasTextures) gl.deleteTexture(tex);
+            this._atlasTextures = [];
+            this._atlasManager = this._createAtlasManager(gl);
             this._pieceTextureCache.clear();
             this._mediaTexture = null;
             this._mediaTextureW = 0;
@@ -368,32 +453,35 @@
                 varying vec2 v_mediaUv;
                 uniform float u_mode;
                 uniform sampler2D u_media;
-                uniform sampler2D u_mask;
-                uniform sampler2D u_overlay;
+                uniform sampler2D u_atlas;
+                uniform vec4 u_maskAtlasRect;
+                uniform vec4 u_overlayAtlasRect;
                 uniform float u_alpha;
                 uniform vec2 u_texel;
                 uniform float u_softness;
                 void main() {
+                    vec2 maskUV = mix(u_maskAtlasRect.xy, u_maskAtlasRect.zw, v_texCoord);
+                    vec2 overlayUV = mix(u_overlayAtlasRect.xy, u_overlayAtlasRect.zw, v_texCoord);
                     if (u_mode < 0.5) {
                         vec2 d = u_texel * u_softness;
                         float alpha = 0.0;
-                        alpha += texture2D(u_mask, v_texCoord).a * 0.227027;
-                        alpha += texture2D(u_mask, v_texCoord + vec2( d.x, 0.0)).a * 0.1945946;
-                        alpha += texture2D(u_mask, v_texCoord + vec2(-d.x, 0.0)).a * 0.1945946;
-                        alpha += texture2D(u_mask, v_texCoord + vec2(0.0,  d.y)).a * 0.1945946;
-                        alpha += texture2D(u_mask, v_texCoord + vec2(0.0, -d.y)).a * 0.1945946;
-                        alpha += texture2D(u_mask, v_texCoord + vec2( d.x,  d.y)).a * 0.1216216;
-                        alpha += texture2D(u_mask, v_texCoord + vec2(-d.x,  d.y)).a * 0.1216216;
-                        alpha += texture2D(u_mask, v_texCoord + vec2( d.x, -d.y)).a * 0.1216216;
-                        alpha += texture2D(u_mask, v_texCoord + vec2(-d.x, -d.y)).a * 0.1216216;
+                        alpha += texture2D(u_atlas, maskUV).a * 0.227027;
+                        alpha += texture2D(u_atlas, maskUV + vec2( d.x, 0.0)).a * 0.1945946;
+                        alpha += texture2D(u_atlas, maskUV + vec2(-d.x, 0.0)).a * 0.1945946;
+                        alpha += texture2D(u_atlas, maskUV + vec2(0.0,  d.y)).a * 0.1945946;
+                        alpha += texture2D(u_atlas, maskUV + vec2(0.0, -d.y)).a * 0.1945946;
+                        alpha += texture2D(u_atlas, maskUV + vec2( d.x,  d.y)).a * 0.1216216;
+                        alpha += texture2D(u_atlas, maskUV + vec2(-d.x,  d.y)).a * 0.1216216;
+                        alpha += texture2D(u_atlas, maskUV + vec2( d.x, -d.y)).a * 0.1216216;
+                        alpha += texture2D(u_atlas, maskUV + vec2(-d.x, -d.y)).a * 0.1216216;
                         alpha = alpha * 0.62;
                         gl_FragColor = vec4(0.0, 0.0, 0.0, alpha * u_alpha);
                     } else if (u_mode < 1.5) {
                         vec4 media = texture2D(u_media, v_mediaUv);
-                        float alpha = texture2D(u_mask, v_texCoord).a;
+                        float alpha = texture2D(u_atlas, maskUV).a;
                         gl_FragColor = vec4(media.rgb, media.a * alpha);
                     } else {
-                        gl_FragColor = texture2D(u_overlay, v_texCoord);
+                        gl_FragColor = texture2D(u_atlas, overlayUV);
                     }
                 }
             `;
@@ -514,8 +602,10 @@
         _pruneTextureCache(visibleFrameMark) {
             for (const [piece, entry] of this._pieceTextureCache.entries()) {
                 if (!entry || entry.lastSeenFrame !== visibleFrameMark) {
-                    if (this.gl && entry.maskTexture) this.gl.deleteTexture(entry.maskTexture);
-                    if (this.gl && entry.overlayTexture) this.gl.deleteTexture(entry.overlayTexture);
+                    if (this._atlasManager && entry.atlasIndex != null) {
+                        this._atlasManager.release(entry.atlasIndex, entry.maskX, entry.maskY, entry.maskW, entry.maskH);
+                        this._atlasManager.release(entry.overlayAtlasIndex, entry.overlayX, entry.overlayY, entry.overlayW, entry.overlayH);
+                    }
                     this._pieceTextureCache.delete(piece);
                 }
             }
@@ -524,42 +614,64 @@
         _ensurePieceTextures(pp, sceneState) {
             const gl = this.gl;
             const puzzle = this.puzzle;
-            if (!puzzle) return null;
+            if (!puzzle || !this._atlasManager) return null;
             const w = Math.max(1, pp.nx * puzzle.scalex);
             const h = Math.max(1, pp.ny * puzzle.scaley);
             if (w <= 0 || h <= 0 || !pp.path) return null;
 
             let entry = this._pieceTextureCache.get(pp);
+            if (entry && (w > entry.maskW || h > entry.maskH)) {
+                this._atlasManager.release(entry.atlasIndex, entry.maskX, entry.maskY, entry.maskW, entry.maskH);
+                this._atlasManager.release(entry.overlayAtlasIndex, entry.overlayX, entry.overlayY, entry.overlayW, entry.overlayH);
+                this._pieceTextureCache.delete(pp);
+                entry = null;
+            }
             if (!entry) {
+                const oversample = this._isOverlayOversampleEnabled();
+                let ow = oversample ? Math.min(2048, Math.max(1, 2 * (w | 0))) : (w | 0);
+                let oh = oversample ? Math.min(2048, Math.max(1, 2 * (h | 0))) : (h | 0);
+                const oversampleFits = ow >= 2 * (w | 0) && oh >= 2 * (h | 0);
+                if (oversample && !oversampleFits) {
+                    ow = Math.max(1, w | 0);
+                    oh = Math.max(1, h | 0);
+                }
+                const maskAlloc = this._atlasManager.allocate(w, h);
+                if (!maskAlloc) return null;
+                const overlayAlloc = this._atlasManager.allocateFromAtlas(maskAlloc.atlasIndex, ow, oh)
+                    || this._atlasManager.allocate(ow, oh);
+                if (!overlayAlloc) return null;
                 entry = {
-                    maskTexture: gl.createTexture(),
-                    overlayTexture: gl.createTexture(),
+                    atlasIndex: maskAlloc.atlasIndex,
+                    overlayAtlasIndex: overlayAlloc.atlasIndex,
+                    maskX: maskAlloc.x,
+                    maskY: maskAlloc.y,
+                    maskW: maskAlloc.w,
+                    maskH: maskAlloc.h,
+                    overlayX: overlayAlloc.x,
+                    overlayY: overlayAlloc.y,
+                    overlayW: overlayAlloc.w,
+                    overlayH: overlayAlloc.h,
                     maskVersion: -1,
                     overlayVersion: -1,
-                    maskConfigured: false,
-                    overlayConfigured: false,
-                    maskW: 0,
-                    maskH: 0,
+                    maskW_texel: w,
+                    maskH_texel: h,
                     lastSeenFrame: 0
                 };
                 this._pieceTextureCache.set(pp, entry);
             }
-            if (!entry.maskTexture || !entry.overlayTexture) return null;
             if (entry.lastSeenFrame == null) entry.lastSeenFrame = 0;
 
             const maskVersion = pp._maskVersion != null ? pp._maskVersion : (pp._overlayVersion || 0);
             if (entry.maskVersion !== maskVersion) {
                 const budget = this._uploadBudgetPerFrame != null ? this._uploadBudgetPerFrame : 12;
                 if (this._uploadCountThisFrame < budget) {
-                    this._bindTextureUnit(1, entry.maskTexture);
-                    if (!entry.maskConfigured) {
-                        this._configureMaskTextureDefaults(entry.maskTexture);
-                        entry.maskConfigured = true;
-                    }
+                    const atlasTex = this._atlasTextures[entry.atlasIndex];
+                    if (!atlasTex) return null;
+                    this._bindTextureUnit(0, atlasTex);
                     gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
                     try {
                         if (pp._maskCanvas) {
-                            gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, pp._maskCanvas);
+                            gl.texSubImage2D(gl.TEXTURE_2D, 0, entry.maskX, entry.maskY, gl.RGBA, gl.UNSIGNED_BYTE, pp._maskCanvas);
                         } else {
                             const mctx = this._ensureSharedMaskCanvas(w, h);
                             if (mctx) {
@@ -567,7 +679,7 @@
                                 mctx.clearRect(0, 0, w, h);
                                 mctx.fillStyle = "#fff";
                                 mctx.fill(pp.path);
-                                gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, this._sharedMaskCanvas);
+                                gl.texSubImage2D(gl.TEXTURE_2D, 0, entry.maskX, entry.maskY, gl.RGBA, gl.UNSIGNED_BYTE, this._sharedMaskCanvas);
                             }
                         }
                         this._uploadCountThisFrame += 1;
@@ -576,19 +688,17 @@
                         return null;
                     }
                     entry.maskVersion = maskVersion;
-                    entry.maskW = w;
-                    entry.maskH = h;
+                    entry.maskW_texel = w;
+                    entry.maskH_texel = h;
                 }
             }
 
             if (entry.overlayVersion !== (pp._overlayVersion || 0)) {
                 const budget = this._uploadBudgetPerFrame != null ? this._uploadBudgetPerFrame : 12;
                 if (this._uploadCountThisFrame < budget) {
-                    this._bindTextureUnit(0, entry.overlayTexture);
-                    if (!entry.overlayConfigured) {
-                        this._configureTextureDefaults(entry.overlayTexture);
-                        entry.overlayConfigured = true;
-                    }
+                    const atlasTex = this._atlasTextures[entry.overlayAtlasIndex];
+                    if (!atlasTex) return null;
+                    this._bindTextureUnit(0, atlasTex);
                     gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
                     try {
                         if (typeof pp.drawOverlayToContext === "function") {
@@ -611,7 +721,7 @@
                             } else {
                                 pp.drawOverlayToContext(octx, w, h, puzzle);
                             }
-                            gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, this._sharedOverlayCanvas);
+                            gl.texSubImage2D(gl.TEXTURE_2D, 0, entry.overlayX, entry.overlayY, gl.RGBA, gl.UNSIGNED_BYTE, this._sharedOverlayCanvas);
                             this._uploadCountThisFrame += 1;
                         }
                     } catch (e) {
@@ -752,8 +862,9 @@
                 uResolution: gl.getUniformLocation(program, "u_resolution"),
                 uMode: null,
                 uMedia: null,
-                uMask: null,
-                uOverlay: null,
+                uAtlas: null,
+                uMaskAtlasRect: null,
+                uOverlayAtlasRect: null,
                 uAlpha: null,
                 uTexel: null,
                 uSoftness: null
@@ -761,8 +872,9 @@
             if (kind === "combined") {
                 info.uMode = gl.getUniformLocation(program, "u_mode");
                 info.uMedia = gl.getUniformLocation(program, "u_media");
-                info.uMask = gl.getUniformLocation(program, "u_mask");
-                info.uOverlay = gl.getUniformLocation(program, "u_overlay");
+                info.uAtlas = gl.getUniformLocation(program, "u_atlas");
+                info.uMaskAtlasRect = gl.getUniformLocation(program, "u_maskAtlasRect");
+                info.uOverlayAtlasRect = gl.getUniformLocation(program, "u_overlayAtlasRect");
                 info.uAlpha = gl.getUniformLocation(program, "u_alpha");
                 info.uTexel = gl.getUniformLocation(program, "u_texel");
                 info.uSoftness = gl.getUniformLocation(program, "u_softness");

--- a/src/render/webgl/WebGLRenderer.js
+++ b/src/render/webgl/WebGLRenderer.js
@@ -16,9 +16,7 @@
             this.puzzle = null;
             this.supportsPieceRendering = false;
             this._eventsBound = false;
-            this._mediaProgram = null;
-            this._overlayProgram = null;
-            this._shadowProgram = null;
+            this._pieceProgram = null;
             this._vertexBuffer = null;
             this._pieceTextureCache = new Map();
             this._mediaTexture = null;
@@ -30,7 +28,6 @@
             this._fatalErrorLogged = false;
             this.failureReason = "";
             this.mediaSource = null;
-            this._boundProgram = null;
             this._boundTexture0 = null;
             this._boundTexture1 = null;
             this._activeTextureUnit = -1;
@@ -161,7 +158,7 @@
                 gl.viewport(0, 0, this.canvas.width, this.canvas.height);
                 gl.clearColor(0, 0, 0, 0);
                 gl.clear(gl.COLOR_BUFFER_BIT);
-                if (!this.puzzle || !this._mediaProgram || !this._overlayProgram || !this._shadowProgram) return;
+                if (!this.puzzle || !this._pieceProgram) return;
 
                 const sourceCanvas = this.puzzle.gameCanvas || null;
                 const videoSource = (this.mediaSource && typeof this.mediaSource.videoWidth === "number" && typeof this.mediaSource.videoHeight === "number") ? this.mediaSource : null;
@@ -253,31 +250,43 @@
                     gl.bindBuffer(gl.ARRAY_BUFFER, this._vertexBuffer);
                     gl.bufferData(gl.ARRAY_BUFFER, this._batchedVertices.subarray(0, requiredFloats), gl.STREAM_DRAW);
 
+                    gl.useProgram(this._pieceProgram.program);
+                    gl.enableVertexAttribArray(this._pieceProgram.aPosition);
+                    gl.enableVertexAttribArray(this._pieceProgram.aTexCoord);
+                    gl.enableVertexAttribArray(this._pieceProgram.aMediaUv);
+                    if (this._pieceProgram._resolutionAppliedSerial !== this._resolutionSerial) {
+                        gl.uniform2f(this._pieceProgram.uResolution, this._displayWidth || this.canvas.width, this._displayHeight || this.canvas.height);
+                        this._pieceProgram._resolutionAppliedSerial = this._resolutionSerial;
+                    }
+
                     for (const item of drawItems) {
                         if (item.held && item.shadowVertexOffsetFloats >= 0) {
-                            this._bindProgram(this._shadowProgram, item.shadowVertexOffsetFloats * 4);
+                            this._setVertexOffset(item.shadowVertexOffsetFloats * 4);
+                            gl.uniform1f(this._pieceProgram.uMode, 0.0);
                             this._bindTextureUnit(0, item.maskTexture);
-                            gl.uniform1i(this._shadowProgram.uMask, 0);
-                            gl.uniform1f(this._shadowProgram.uAlpha, item.heldShadowAlpha);
+                            gl.uniform1i(this._pieceProgram.uMask, 0);
+                            gl.uniform1f(this._pieceProgram.uAlpha, item.heldShadowAlpha);
                             gl.uniform2f(
-                                this._shadowProgram.uTexel,
+                                this._pieceProgram.uTexel,
                                 1 / Math.max(1, item.maskW),
                                 1 / Math.max(1, item.maskH)
                             );
-                            gl.uniform1f(this._shadowProgram.uSoftness, 3.0);
+                            gl.uniform1f(this._pieceProgram.uSoftness, 3.0);
                             gl.drawArrays(gl.TRIANGLES, 0, 6);
                         }
 
-                        this._bindProgram(this._mediaProgram, item.pieceVertexOffsetFloats * 4);
+                        this._setVertexOffset(item.pieceVertexOffsetFloats * 4);
+                        gl.uniform1f(this._pieceProgram.uMode, 1.0);
                         this._bindTextureUnit(0, this._mediaTexture);
-                        gl.uniform1i(this._mediaProgram.uMedia, 0);
+                        gl.uniform1i(this._pieceProgram.uMedia, 0);
                         this._bindTextureUnit(1, item.maskTexture);
-                        gl.uniform1i(this._mediaProgram.uMask, 1);
+                        gl.uniform1i(this._pieceProgram.uMask, 1);
                         gl.drawArrays(gl.TRIANGLES, 0, 6);
 
-                        this._bindProgram(this._overlayProgram, item.pieceVertexOffsetFloats * 4);
+                        this._setVertexOffset(item.pieceVertexOffsetFloats * 4);
+                        gl.uniform1f(this._pieceProgram.uMode, 2.0);
                         this._bindTextureUnit(0, item.overlayTexture);
-                        gl.uniform1i(this._overlayProgram.uOverlay, 0);
+                        gl.uniform1i(this._pieceProgram.uOverlay, 0);
                         gl.drawArrays(gl.TRIANGLES, 0, 6);
                     }
                 }
@@ -307,17 +316,13 @@
                 this._pieceTextureCache.clear();
                 if (this._vertexBuffer) this.gl.deleteBuffer(this._vertexBuffer);
                 if (this._mediaTexture) this.gl.deleteTexture(this._mediaTexture);
-                if (this._mediaProgram && this._mediaProgram.program) this.gl.deleteProgram(this._mediaProgram.program);
-                if (this._overlayProgram && this._overlayProgram.program) this.gl.deleteProgram(this._overlayProgram.program);
-                if (this._shadowProgram && this._shadowProgram.program) this.gl.deleteProgram(this._shadowProgram.program);
+                if (this._pieceProgram && this._pieceProgram.program) this.gl.deleteProgram(this._pieceProgram.program);
             }
             this._vertexBuffer = null;
             this._mediaTexture = null;
             this._mediaTextureW = 0;
             this._mediaTextureH = 0;
-            this._mediaProgram = null;
-            this._overlayProgram = null;
-            this._shadowProgram = null;
+            this._pieceProgram = null;
             if (this.canvas.parentElement) this.canvas.parentElement.removeChild(this.canvas);
             this.gl = null;
         }
@@ -327,9 +332,7 @@
             const gl = this.gl;
             if (this._vertexBuffer) gl.deleteBuffer(this._vertexBuffer);
             if (this._mediaTexture) gl.deleteTexture(this._mediaTexture);
-            if (this._mediaProgram && this._mediaProgram.program) gl.deleteProgram(this._mediaProgram.program);
-            if (this._overlayProgram && this._overlayProgram.program) gl.deleteProgram(this._overlayProgram.program);
-            if (this._shadowProgram && this._shadowProgram.program) gl.deleteProgram(this._shadowProgram.program);
+            if (this._pieceProgram && this._pieceProgram.program) gl.deleteProgram(this._pieceProgram.program);
             for (const entry of this._pieceTextureCache.values()) {
                 if (entry.maskTexture) gl.deleteTexture(entry.maskTexture);
                 if (entry.overlayTexture) gl.deleteTexture(entry.overlayTexture);
@@ -339,7 +342,6 @@
             this._mediaTextureW = 0;
             this._mediaTextureH = 0;
             this._mediaTextureConfigured = false;
-            this._boundProgram = null;
             this._boundTexture0 = null;
             this._boundTexture1 = null;
             this._activeTextureUnit = -1;
@@ -360,53 +362,43 @@
                     v_mediaUv = a_mediaUv;
                 }
             `;
-            const mediaFragSrc = `
+            const combinedFragSrc = `
                 precision mediump float;
                 varying vec2 v_texCoord;
                 varying vec2 v_mediaUv;
+                uniform float u_mode;
                 uniform sampler2D u_media;
                 uniform sampler2D u_mask;
-                void main() {
-                    vec4 media = texture2D(u_media, v_mediaUv);
-                    float alpha = texture2D(u_mask, v_texCoord).a;
-                    gl_FragColor = vec4(media.rgb, media.a * alpha);
-                }
-            `;
-            const overlayFragSrc = `
-                precision mediump float;
-                varying vec2 v_texCoord;
                 uniform sampler2D u_overlay;
-                void main() {
-                    gl_FragColor = texture2D(u_overlay, v_texCoord);
-                }
-            `;
-            const shadowFragSrc = `
-                precision mediump float;
-                varying vec2 v_texCoord;
-                uniform sampler2D u_mask;
                 uniform float u_alpha;
                 uniform vec2 u_texel;
                 uniform float u_softness;
                 void main() {
-                    vec2 d = u_texel * u_softness;
-                    float alpha = 0.0;
-                    alpha += texture2D(u_mask, v_texCoord).a * 0.227027;
-                    alpha += texture2D(u_mask, v_texCoord + vec2( d.x, 0.0)).a * 0.1945946;
-                    alpha += texture2D(u_mask, v_texCoord + vec2(-d.x, 0.0)).a * 0.1945946;
-                    alpha += texture2D(u_mask, v_texCoord + vec2(0.0,  d.y)).a * 0.1945946;
-                    alpha += texture2D(u_mask, v_texCoord + vec2(0.0, -d.y)).a * 0.1945946;
-                    alpha += texture2D(u_mask, v_texCoord + vec2( d.x,  d.y)).a * 0.1216216;
-                    alpha += texture2D(u_mask, v_texCoord + vec2(-d.x,  d.y)).a * 0.1216216;
-                    alpha += texture2D(u_mask, v_texCoord + vec2( d.x, -d.y)).a * 0.1216216;
-                    alpha += texture2D(u_mask, v_texCoord + vec2(-d.x, -d.y)).a * 0.1216216;
-                    alpha = alpha * 0.62;
-                    gl_FragColor = vec4(0.0, 0.0, 0.0, alpha * u_alpha);
+                    if (u_mode < 0.5) {
+                        vec2 d = u_texel * u_softness;
+                        float alpha = 0.0;
+                        alpha += texture2D(u_mask, v_texCoord).a * 0.227027;
+                        alpha += texture2D(u_mask, v_texCoord + vec2( d.x, 0.0)).a * 0.1945946;
+                        alpha += texture2D(u_mask, v_texCoord + vec2(-d.x, 0.0)).a * 0.1945946;
+                        alpha += texture2D(u_mask, v_texCoord + vec2(0.0,  d.y)).a * 0.1945946;
+                        alpha += texture2D(u_mask, v_texCoord + vec2(0.0, -d.y)).a * 0.1945946;
+                        alpha += texture2D(u_mask, v_texCoord + vec2( d.x,  d.y)).a * 0.1216216;
+                        alpha += texture2D(u_mask, v_texCoord + vec2(-d.x,  d.y)).a * 0.1216216;
+                        alpha += texture2D(u_mask, v_texCoord + vec2( d.x, -d.y)).a * 0.1216216;
+                        alpha += texture2D(u_mask, v_texCoord + vec2(-d.x, -d.y)).a * 0.1216216;
+                        alpha = alpha * 0.62;
+                        gl_FragColor = vec4(0.0, 0.0, 0.0, alpha * u_alpha);
+                    } else if (u_mode < 1.5) {
+                        vec4 media = texture2D(u_media, v_mediaUv);
+                        float alpha = texture2D(u_mask, v_texCoord).a;
+                        gl_FragColor = vec4(media.rgb, media.a * alpha);
+                    } else {
+                        gl_FragColor = texture2D(u_overlay, v_texCoord);
+                    }
                 }
             `;
-            this._mediaProgram = this._createProgramInfo(vertexSrc, mediaFragSrc, "media");
-            this._overlayProgram = this._createProgramInfo(vertexSrc, overlayFragSrc, "overlay");
-            this._shadowProgram = this._createProgramInfo(vertexSrc, shadowFragSrc, "shadow");
-            if (!this._mediaProgram || !this._overlayProgram || !this._shadowProgram) return false;
+            this._pieceProgram = this._createProgramInfo(vertexSrc, combinedFragSrc, "combined");
+            if (!this._pieceProgram) return false;
             this._vertexBuffer = gl.createBuffer();
             if (!this._vertexBuffer) return false;
             gl.disable(gl.DEPTH_TEST);
@@ -635,25 +627,12 @@
             return entry;
         }
 
-        _bindProgram(programInfo, byteOffset) {
+        _setVertexOffset(byteOffset) {
             const gl = this.gl;
             const offset = byteOffset || 0;
-            if (this._boundProgram !== programInfo.program) {
-                gl.useProgram(programInfo.program);
-                this._boundProgram = programInfo.program;
-            }
-            gl.enableVertexAttribArray(programInfo.aPosition);
-            gl.vertexAttribPointer(programInfo.aPosition, 2, gl.FLOAT, false, 24, offset);
-            gl.enableVertexAttribArray(programInfo.aTexCoord);
-            gl.vertexAttribPointer(programInfo.aTexCoord, 2, gl.FLOAT, false, 24, offset + 8);
-            if (programInfo.aMediaUv >= 0) {
-                gl.enableVertexAttribArray(programInfo.aMediaUv);
-                gl.vertexAttribPointer(programInfo.aMediaUv, 2, gl.FLOAT, false, 24, offset + 16);
-            }
-            if (programInfo._resolutionAppliedSerial !== this._resolutionSerial) {
-                gl.uniform2f(programInfo.uResolution, this._displayWidth || this.canvas.width, this._displayHeight || this.canvas.height);
-                programInfo._resolutionAppliedSerial = this._resolutionSerial;
-            }
+            gl.vertexAttribPointer(this._pieceProgram.aPosition, 2, gl.FLOAT, false, 24, offset);
+            gl.vertexAttribPointer(this._pieceProgram.aTexCoord, 2, gl.FLOAT, false, 24, offset + 8);
+            gl.vertexAttribPointer(this._pieceProgram.aMediaUv, 2, gl.FLOAT, false, 24, offset + 16);
         }
 
         _configureTextureDefaults(texture) {
@@ -771,6 +750,7 @@
                 aTexCoord: gl.getAttribLocation(program, "a_texCoord"),
                 aMediaUv: gl.getAttribLocation(program, "a_mediaUv"),
                 uResolution: gl.getUniformLocation(program, "u_resolution"),
+                uMode: null,
                 uMedia: null,
                 uMask: null,
                 uOverlay: null,
@@ -778,13 +758,11 @@
                 uTexel: null,
                 uSoftness: null
             };
-            if (kind === "media") {
+            if (kind === "combined") {
+                info.uMode = gl.getUniformLocation(program, "u_mode");
                 info.uMedia = gl.getUniformLocation(program, "u_media");
                 info.uMask = gl.getUniformLocation(program, "u_mask");
-            } else if (kind === "overlay") {
                 info.uOverlay = gl.getUniformLocation(program, "u_overlay");
-            } else if (kind === "shadow") {
-                info.uMask = gl.getUniformLocation(program, "u_mask");
                 info.uAlpha = gl.getUniformLocation(program, "u_alpha");
                 info.uTexel = gl.getUniformLocation(program, "u_texel");
                 info.uSoftness = gl.getUniformLocation(program, "u_softness");

--- a/src/render/webgl/WebGLRenderer.js
+++ b/src/render/webgl/WebGLRenderer.js
@@ -94,7 +94,8 @@
             if (!this.canvas.parentElement) this.container.appendChild(this.canvas);
             this.canvas.style.width = "100%";
             this.canvas.style.height = "100%";
-            this.gl = this.canvas.getContext("webgl2") || this.canvas.getContext("webgl");
+            const glOpts = { powerPreference: "high-performance" };
+            this.gl = this.canvas.getContext("webgl2", glOpts) || this.canvas.getContext("webgl", glOpts);
             if (!this.gl) {
                 this.enabled = false;
                 this.supportsPieceRendering = false;

--- a/src/ui/RendererModeControl.js
+++ b/src/ui/RendererModeControl.js
@@ -129,8 +129,9 @@
             const videoFrameRateSelect = document.getElementById("videoFrameRateSelect");
             if (videoFrameRateSelect) {
                 const viewState = globalScope.viewState;
-                const validValues = ["0", "16", "33", "42", "50", "66"];
-                const initialMs = (viewState && typeof viewState.videoFrameIntervalMs === "number") ? viewState.videoFrameIntervalMs : 33;
+                const validValues = ["33", "42", "50", "66"];
+                let initialMs = (viewState && typeof viewState.videoFrameIntervalMs === "number") ? viewState.videoFrameIntervalMs : 33;
+                if (initialMs <= 0 || initialMs < 33) initialMs = 33;
                 const initialValue = String(validValues.includes(String(initialMs)) ? initialMs : 33);
                 videoFrameRateSelect.value = initialValue;
                 const facade = deps.getRendererFacade();

--- a/src/ui/ViewControls.js
+++ b/src/ui/ViewControls.js
@@ -259,7 +259,7 @@
             viewState.panY = clamp(viewState.panY, -maxOffset, maxOffset);
         }
 
-        function applyViewTransform() {
+        function applyViewTransform(panOnly = false) {
             clampPanToBounds();
             const baseScale = getActiveBaseScale();
             // Keep container centering stable even when layout metrics momentarily report
@@ -276,7 +276,7 @@
             const puzzle = getPuzzle();
             if (puzzle) {
                 if (puzzle._invalidateViewMetricsCache) puzzle._invalidateViewMetricsCache();
-                if (Number.isFinite(puzzle.scalex)) puzzle.refreshConnectionDistance();
+                if (!panOnly && Number.isFinite(puzzle.scalex)) puzzle.refreshConnectionDistance();
             }
         }
 

--- a/style.css
+++ b/style.css
@@ -986,6 +986,7 @@
     .resizer.corner { 
         right: 0; bottom: 0; width: 15px; height: 15px; 
         cursor: nwse-resize; background: #888; border-radius: 3px;
+        touch-action: none; /* prevent browser pan/scroll when dragging resize handle on mobile */
     }
 
     /* Chat / Log window – themed like the drawer */
@@ -1013,6 +1014,9 @@
         min-height: 0;
         height: auto;
         max-height: calc(100vh - 110px);
+      }
+      #draggable6 {
+        min-height: 200px; 
       }
       #draggable4 .resizer.corner,
       #draggable5 .resizer.corner,


### PR DESCRIPTION
Just gonna keep reusing this same branch until there's nothing left to fix. 

- Remove shadowblur in canvas2d (+CPU)
- Cap the overall loop rate so we don't do extra math for no reason (+CPU/+GPU)
- Optimize canvas2d some by moving the held piece to its own cavnas so dragging pieces doesn't force a full redraw (+CPU/-MEM)
- Pan optimizations (++CPU/+GPU)
- Fix animations marking all pieces dirty every frame (+++GPU)
- Fix panel resize dragging screen + media panel made for ants